### PR TITLE
Fix to work with IPv6

### DIFF
--- a/src/src/configure.default
+++ b/src/src/configure.default
@@ -56,7 +56,7 @@
 
 domainlist local_domains = @
 domainlist relay_to_domains =
-hostlist   relay_from_hosts = 127.0.0.1
+hostlist   relay_from_hosts = localhost
 
 # Most straightforward access control requirements can be obtained by
 # appropriate settings of the above options. In more complicated situations,
@@ -91,12 +91,19 @@ hostlist   relay_from_hosts = 127.0.0.1
 # to any other host on the Internet. Such a setting commonly refers to a
 # complete local network as well as the localhost. For example:
 #
-# hostlist relay_from_hosts = 127.0.0.1 : 192.168.0.0/16
+# hostlist relay_from_hosts = localhost : 192.168.0.0/16
 #
+# Avoid using IP addresses like 127.0.0.1 since these will not work in an
+# environment that also uses IPv6. Your /etc/hosts should contain both
+# 127.0.0.1 and ::1 as localhost.
+# If you MUST use numeric addresses you can specify:
+# hostlist relay_from_hosts = <; 127.0.0.1; ::1; 192.168.0.0/16
+
 # The "/16" is a bit mask (CIDR notation), not a number of hosts. Note that you
 # have to include 127.0.0.1 if you want to allow processes on your host to send
 # SMTP mail by using the loopback address. A number of MUAs use this method of
 # sending mail.
+# Do not forget CIDR for your IPv6 networks.
 
 # All three of these lists may contain many different kinds of item, including
 # wildcarded names, regular expressions, and file lookups. See the reference
@@ -538,7 +545,7 @@ dnslookup:
   driver = dnslookup
   domains = ! +local_domains
   transport = remote_smtp
-  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
+  ignore_target_hosts = <; 0.0.0.0; 127.0.0.0/8; ::1
   no_more
 
 
@@ -553,7 +560,7 @@ dnslookup:
 #   domains = ! +local_domains
 #   transport = remote_smtp
 #   route_data = MAIL.HOSTNAME.FOR.CENTRAL.SERVER.EXAMPLE
-#   ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
+#   ignore_target_hosts = <; 0.0.0.0; 127.0.0.0/8; ::1
 #   no_more
 
 


### PR DESCRIPTION
Previously using localhost as 127.0.0.1 failed with relays from the IPv6
localhost (::1). I have suggested use of 'localhost' and have changed some
others to be IPv6 aware
