### PR TITLE
redis lookup returns false for things that should be true

### DIFF
--- a/src/src/lookups/redis.c
+++ b/src/src/lookups/redis.c
@@ -211,7 +211,7 @@ perform_redis_search(uschar *command, uschar *server, uschar **resultptr,
 
                break;
        case REDIS_REPLY_INTEGER:
-               ttmp = (redis_reply->integer == 1) ? US"true" : US"false";
+               ttmp = (redis_reply->integer != 0) ? US"true" : US"false";
                result = string_cat(result, &ssize, &offset, US ttmp, Ustrlen(ttmp));
                break;
        case REDIS_REPLY_STRING:


### PR DESCRIPTION
If redis returns an integer the lookup code currently checks if the value is 1 and returns false for all other values.
This is problematic if you want to use redis commands that return counts (ZCARD etc.) because you can't check for "does not exist" or "exists at least once". (It will be 0->false, 1->true, 2 or more-> false again)

This commit changes the code to handle integer values like C: 0 is false and everything else is true.

For the simple 0 and 1 values nothing changes to existing queries so this diff is backwards compatible.
For queries that return other values exim now gets the bool that would be expected.
