### PR TITLE
tls_field_from_dn() fix for custom out separator

### DIFF
--- a/src/src/tls.c
+++ b/src/src/tls.c
@@ -249,10 +249,18 @@ while ((ele = string_nextinlist(&mod, &insep, NULL, 0)))
 
 dn_to_list(dn);
 insep = ',';
-len = Ustrlen(match);
-while ((ele = string_nextinlist(&dn, &insep, NULL, 0)))
-  if (Ustrncmp(ele, match, len) == 0 && ele[len] == '=')
-    list = string_append_listele(list, outsep, ele+len+1);
+if (match)
+  {
+  len = Ustrlen(match);
+  while ((ele = string_nextinlist(&dn, &insep, NULL, 0)))
+    if (Ustrncmp(ele, match, len) == 0 && ele[len] == '=')
+      list = string_append_listele(list, outsep, ele+len+1);
+  }
+else
+  {
+  while ((ele = string_nextinlist(&dn, &insep, NULL, 0)))
+    list = string_append_listele(list, outsep, ele);
+  }
 return list;
 }
 


### PR DESCRIPTION
Fixes a bug in ${certextract ...} clause when handling custom separator for RFC4514 DN.
Example:
${certextract{subject,>/}{$tls_in_ourcert}}
Exim process gets SIGSEGV due to strlen(NULL) call (match == NULL).
