### PR TITLE
tls_in_peerdn/tls_in_peercert fix for OpenSSL

### DIFF
--- a/src/src/tls-openssl.c
+++ b/src/src/tls-openssl.c
@@ -277,7 +277,12 @@ verify_callback(int state, X509_STORE_CTX *x509ctx,
 X509 * cert = X509_STORE_CTX_get_current_cert(x509ctx);
 static uschar txt[256];
 
+if (tlsp->peercert)
+  X509_free(tlsp->peercert);
+tlsp->peercert = X509_dup(cert);
+
 X509_NAME_oneline(X509_get_subject_name(cert), CS txt, sizeof(txt));
+tlsp->peerdn = txt;
 
 if (state == 0)
   {
@@ -289,7 +294,6 @@ if (state == 0)
   *calledp = TRUE;
   if (!*optionalp)
     {
-    tlsp->peercert = X509_dup(cert);
     return 0;			    /* reject */
     }
   DEBUG(D_tls) debug_printf("SSL verify failure overridden (host in "
@@ -317,9 +321,6 @@ else
 #ifdef EXPERIMENTAL_CERTNAMES
   uschar * verify_cert_hostnames;
 #endif
-
-  tlsp->peerdn = txt;
-  tlsp->peercert = X509_dup(cert);
 
 #ifdef EXPERIMENTAL_CERTNAMES
   if (  tlsp == &tls_out


### PR DESCRIPTION
Fixed $tls_in_peercert and $tls_in_peerdn variables unavailability when compiled with OpenSSL.
