### PR TITLE
Add support for freeradius-client

### DIFF
--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -940,6 +940,9 @@ ZCAT_COMMAND=/usr/bin/zcat
 # RADIUSCLIENT is the radiusclient library; you probably need to add
 #   -lradiusclient to EXTRALIBS.
 #
+# RADIUSCLIENTNEW is the freeradius-client library; you probably need to add
+#   -lfreeradius-client to EXTRALIBS.
+#
 # The API for the radiusclient library was changed at release 0.4.0.
 # Unfortunately, the header file does not define a version number that clients
 # can use to support both the old and new APIs. If you are using version 0.4.0

--- a/src/src/auths/call_radius.c
+++ b/src/src/auths/call_radius.c
@@ -38,7 +38,11 @@ using its original API. At release 0.4.0 the API changed. */
   #if !defined(RADIUS_LIB_RADIUSCLIENT) && !defined(RADIUS_LIB_RADIUSCLIENTNEW)
   #define RADIUS_LIB_RADIUSCLIENT
   #endif
+  #ifdef RADIUS_LIB_RADIUSCLIENTNEW
+  #include <freeradius-client.h>
+  #else
   #include <radiusclient.h>
+  #endif
 #endif
 
 


### PR DESCRIPTION
radiusclient-ng (mentioned in docs as radiusclient 0.4.0 and above)
is no longer maintained upstream. It was superseded by
freeradius-client. The API is mostly compatible. Header name has
changed and the library name has changed.

Tested, works fine.

Probably some changes in documentation and comments in EDITME are needed, but unfortunately I'm a bad english writer.