### PR TITLE
Rename build-time option TMPDIR to EXIM_TMPDIR

### DIFF
--- a/doc/doc-txt/OptionLists.txt
+++ b/doc/doc-txt/OptionLists.txt
@@ -968,7 +968,7 @@ TCP_WRAPPERS_DAEMON_NAME     system*      daemon name used by tcpwrappers librar
 TIMEZONE_DEFAULT             optional     default for timezone option
 TLS_INCLUDE                  optional     path to include files for TLS
 TLS_LIBS                     optional     additional libraries for TLS
-TMPDIR                       system       value for TMPDIR environment variable
+EXIM_TMPDIR                  system       value for TMPDIR environment variable
 TRANSPORT_APPENDFILE         driver       include appendfile transport
 TRANSPORT_AUTOREPLY          driver       include autoreply transport
 TRANSPORT_LMTP               driver       include lmtp transport

--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -1123,7 +1123,7 @@ SYSTEM_ALIASES_FILE=/etc/aliases
 # it replaces the value with what is defined here. Commenting this setting
 # suppresses the check altogether.
 
-TMPDIR="/tmp"
+EXIM_TMPDIR="/tmp"
 
 
 #------------------------------------------------------------------------------

--- a/src/src/config.h.defaults
+++ b/src/src/config.h.defaults
@@ -150,7 +150,7 @@ it's a default value. */
 
 #define TCP_WRAPPERS_DAEMON_NAME "exim"
 #define TIMEZONE_DEFAULT
-#define TMPDIR
+#define EXIM_TMPDIR
 
 #define TRANSPORT_APPENDFILE
 #define TRANSPORT_AUTOREPLY

--- a/src/src/exim.c
+++ b/src/src/exim.c
@@ -3899,20 +3899,20 @@ if (log_oneline)
 temporary files are created; Exim doesn't use these (apart from when delivering
 to MBX mailboxes), but called libraries such as DBM libraries may require them.
 If TMPDIR is found in the environment, reset it to the value defined in the
-TMPDIR macro, if this macro is defined. */
+EXIM_TMPDIR macro, if this macro is defined. */
 
-#ifdef TMPDIR
+#ifdef EXIM_TMPDIR
   {
   uschar **p;
   for (p = USS environ; *p != NULL; p++)
     {
     if (Ustrncmp(*p, "TMPDIR=", 7) == 0 &&
-        Ustrcmp(*p+7, TMPDIR) != 0)
+        Ustrcmp(*p+7, EXIM_TMPDIR) != 0)
       {
-      uschar *newp = malloc(Ustrlen(TMPDIR) + 8);
-      sprintf(CS newp, "TMPDIR=%s", TMPDIR);
+      uschar *newp = malloc(Ustrlen(EXIM_TMPDIR) + 8);
+      sprintf(CS newp, "TMPDIR=%s", EXIM_TMPDIR);
       *p = newp;
-      DEBUG(D_any) debug_printf("reset TMPDIR=%s in environment\n", TMPDIR);
+      DEBUG(D_any) debug_printf("reset TMPDIR=%s in environment\n", EXIM_TMPDIR);
       }
     }
   }


### PR DESCRIPTION
Build-time option TMPDIR included in Makefile clashes with environment
variable of the same name. This breaks tools that make use of that
variable, such as distcc.

The following example demonstrates what's going on:

$ cat Makefile
TMPDIR="/tmp"
all:
	env
$ export TMPDIR=test
$ make | grep ^TMPDIR
TMPDIR="/tmp"

distcc error (note the extra quotes):
ERROR: can't use TMPDIR ""/tmp"": No such file or directory