### PR TITLE
additonal safeguard for the ʟᴘ64 memory model : prefer size_t over int when appropriate

### DIFF
--- a/doc/doc-docbook/spec.xfpt
+++ b/doc/doc-docbook/spec.xfpt
@@ -32390,7 +32390,7 @@ match the specification, the function does nothing.
 
 
 .vitem "&*BOOL&~header_testname(header_line&~*hdr,&~uschar&~*name,&~&&&
-        int&~length,&~BOOL&~notdel)*&"
+        size_t&~length,&~BOOL&~notdel)*&"
 This function tests whether the given header has the given name. It is not just
 a string comparison, because white space is permitted between the name and the
 colon. If the &%notdel%& argument is true, a false return is forced for all
@@ -32488,7 +32488,7 @@ address.
 .cindex "RFC 2047"
 .vlist
 .vitem "&*uschar&~rfc2047_decode(uschar&~*string,&~BOOL&~lencheck,&&&
-  &~uschar&~*target,&~int&~zeroval,&~int&~*lenptr, &~&~uschar&~**error)*&"
+  &~uschar&~*target,&~int&~zeroval,&~size_t&~*lenptr, &~&~uschar&~**error)*&"
 This function decodes strings that are encoded according to RFC 2047. Typically
 these are the contents of header lines. First, each &"encoded word"& is decoded
 from the Q or B encoding into a byte-string. Then, if provided with the name of

--- a/doc/doc-txt/ChangeLog
+++ b/doc/doc-txt/ChangeLog
@@ -23,6 +23,12 @@ JH/03 Upgrade security requirements imposed for hosts_try_dane: previously
 JH/04 Bug 1810: make continued-use of an open smtp transport connection
       non-noisy when a race steals the message being considered.
 
+LC/01 Prefer the use of size_t for varaibles used for sizes. Even if most strings in
+      Exim are limited to 2¹⁵−1, This acts as a suplemental protection against overflows.
+      Especially for 16 bits x86 where INT_MAX is already 2¹⁵−1 and pointers used in
+      Unix prorgrams are FAR (20 bits wide).
+      In the meantime, this doesn’t impact any cases where negative length could have
+      been used, as an error value.
 
 Exim version 4.87
 -----------------

--- a/src/exim_monitor/em_TextPop.c
+++ b/src/exim_monitor/em_TextPop.c
@@ -468,7 +468,7 @@ struct SearchAndReplace * search;
   text.firstPos = 0;
   text.format = FMT8BIT;
 
-  dir = (XawTextScanDirection)(int) ((caddr_t)XawToggleGetCurrent(search->left_toggle) -
+  dir = (XawTextScanDirection)(size_t) ((caddr_t)XawToggleGetCurrent(search->left_toggle) -
 				R_OFFSET);
 
   pos = XawTextSearch( tw, dir, &text);

--- a/src/exim_monitor/em_hdr.h
+++ b/src/exim_monitor/em_hdr.h
@@ -185,7 +185,7 @@ typedef struct queue_item {
   struct dest_item  *destinations;
   int  input_time;
   int  update_time;
-  int  size;
+  size_t  size;
   uschar *sender;
   uschar name[17];
   uschar seen;

--- a/src/exim_monitor/em_queue.c
+++ b/src/exim_monitor/em_queue.c
@@ -763,7 +763,7 @@ while (p != NULL)
 
     for (skp = &queue_skip; ; skp = &(sk->next))
       {
-      int len_skip;
+      size_t len_skip;
 
       sk = *skp;
       while (sk != NULL && now >= sk->reveal)

--- a/src/exim_monitor/em_strip.c
+++ b/src/exim_monitor/em_strip.c
@@ -63,7 +63,7 @@ static void stripchartAction(Widget w, XtPointer client_data, XtPointer value)
 double *ptr = (double *)value;
 static int thresholds[] =
   {10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 0};
-int num = (int)client_data;
+size_t num = (size_t)client_data;
 int oldmax = 0;
 int newmax = 0;
 int newvalue = 0;

--- a/src/src/acl.c
+++ b/src/src/acl.c
@@ -1048,7 +1048,7 @@ static void
 setup_header(const uschar *hstring)
 {
 const uschar *p, *q;
-int hlen = Ustrlen(hstring);
+size_t hlen = Ustrlen(hstring);
 
 /* Ignore any leading newlines */
 while (*hstring == '\n') hstring++, hlen--;
@@ -1159,8 +1159,8 @@ uschar *
 fn_hdrs_added(void)
 {
 uschar * ret = NULL;
-int size = 0;
-int ptr = 0;
+size_t size = 0;
+size_t ptr = 0;
 header_line * h = acl_added_headers;
 uschar * s;
 uschar * cp;
@@ -1259,7 +1259,7 @@ if (log_message != NULL && log_message != user_message)
 
   if (logged == NULL)
     {
-    int length = Ustrlen(text) + 1;
+    size_t length = Ustrlen(text) + 1;
     log_write(0, LOG_MAIN, "%s", text);
     logged = store_malloc(sizeof(string_item) + length);
     logged->text = (uschar *)logged + sizeof(string_item);
@@ -1651,7 +1651,7 @@ typedef struct {
   int	   value;
   unsigned where_allowed;	/* bitmap */
   BOOL	   no_options;		/* Never has /option(s) following */
-  unsigned alt_opt_sep;		/* >0 Non-/ option separator (custom parser) */
+  size_t alt_opt_sep;		/* >0 Non-/ option separator (custom parser) */
   } verify_type_t;
 static verify_type_t verify_type_list[] = {
     { US"reverse_host_lookup",	VERIFY_REV_HOST_LKUP,	~0,	FALSE, 0 },
@@ -2340,7 +2340,7 @@ int mode = RATE_PER_WHAT;
 int old_pool, rc;
 tree_node **anchor, *t;
 open_db dbblock, *dbm;
-int dbdb_size;
+size_t dbdb_size;
 dbdata_ratelimit *dbd;
 dbdata_ratelimit_unique *dbdb;
 struct timeval tv;

--- a/src/src/auths/check_serv_cond.c
+++ b/src/src/auths/check_serv_cond.c
@@ -72,7 +72,7 @@ HDEBUG(D_auth)
       debug_printf("  $auth%d = %s\n", i + 1, auth_vars[i]);
     }
   for (i = 1; i <= expand_nmax; i++)
-    debug_printf("  $%d = %.*s\n", i, expand_nlength[i], expand_nstring[i]);
+    debug_printf("  $%u = %.*s\n", i, (unsigned int)expand_nlength[i], expand_nstring[i]);
   debug_print_string(ablock->server_debug_string);    /* customized debug */
   }
 

--- a/src/src/auths/cram_md5.c
+++ b/src/src/auths/cram_md5.c
@@ -97,7 +97,7 @@ compute_cram_md5(uschar *secret, uschar *challenge, uschar *digestptr)
 {
 md5 base;
 int i;
-int len = Ustrlen(secret);
+size_t len = Ustrlen(secret);
 uschar isecret[64];
 uschar osecret[64];
 uschar md5secret[16];
@@ -250,7 +250,7 @@ auth_cram_md5_client(
   smtp_outblock *outblock,               /* output connection */
   int timeout,                           /* command timeout */
   uschar *buffer,                        /* for reading response */
-  int buffsize)                          /* size of buffer */
+  size_t buffsize)                          /* size of buffer */
 {
 auth_cram_md5_options_block *ob =
   (auth_cram_md5_options_block *)(ablock->options_block);

--- a/src/src/auths/cram_md5.h
+++ b/src/src/auths/cram_md5.h
@@ -27,6 +27,6 @@ extern auth_cram_md5_options_block auth_cram_md5_option_defaults;
 extern void auth_cram_md5_init(auth_instance *);
 extern int auth_cram_md5_server(auth_instance *, uschar *);
 extern int auth_cram_md5_client(auth_instance *, smtp_inblock *,
-                                smtp_outblock *, int, uschar *, int);
+                                smtp_outblock *, int, uschar *, size_t);
 
 /* End of cram_md5.h */

--- a/src/src/auths/heimdal_gssapi.c
+++ b/src/src/auths/heimdal_gssapi.c
@@ -467,7 +467,7 @@ auth_heimdal_gssapi_server(auth_instance *ablock, uschar *initial_data)
 
         expand_nlength[1] = gbufdesc_out.length;
         auth_vars[0] = expand_nstring[1] =
-          string_copyn(gbufdesc_out.value, gbufdesc_out.length);
+          string_copyn(gbufdesc_out.value, (size_t)gbufdesc_out.length);
 
         if (expand_nmax == 0) { /* should be: authzid was empty */
           expand_nmax = 2;

--- a/src/src/auths/plaintext.c
+++ b/src/src/auths/plaintext.c
@@ -159,7 +159,7 @@ auth_plaintext_client(
   smtp_outblock *outblock,               /* connection outblock */
   int timeout,                           /* command timeout */
   uschar *buffer,                        /* buffer for reading response */
-  int buffsize)                          /* size of buffer */
+  size_t buffsize)                          /* size of buffer */
 {
 auth_plaintext_options_block *ob =
   (auth_plaintext_options_block *)(ablock->options_block);

--- a/src/src/auths/plaintext.h
+++ b/src/src/auths/plaintext.h
@@ -27,6 +27,6 @@ extern auth_plaintext_options_block auth_plaintext_option_defaults;
 extern void auth_plaintext_init(auth_instance *);
 extern int auth_plaintext_server(auth_instance *, uschar *);
 extern int auth_plaintext_client(auth_instance *, smtp_inblock *,
-                                 smtp_outblock *, int, uschar *, int);
+                                 smtp_outblock *, int, uschar *, size_t);
 
 /* End of plaintext.h */

--- a/src/src/auths/spa.c
+++ b/src/src/auths/spa.c
@@ -259,7 +259,7 @@ auth_spa_client(
   smtp_outblock *outblock,               /* connection outblock */
   int timeout,                           /* command timeout */
   uschar *buffer,                        /* buffer for reading response */
-  int buffsize)                          /* size of buffer */
+  size_t buffsize)                          /* size of buffer */
 {
        auth_spa_options_block *ob =
                (auth_spa_options_block *)(ablock->options_block);

--- a/src/src/auths/spa.h
+++ b/src/src/auths/spa.h
@@ -34,6 +34,6 @@ extern auth_spa_options_block auth_spa_option_defaults;
 extern void auth_spa_init(auth_instance *);
 extern int auth_spa_server(auth_instance *, uschar *);
 extern int auth_spa_client(auth_instance *, smtp_inblock *,
-                                 smtp_outblock *, int, uschar *, int);
+                                 smtp_outblock *, int, uschar *, size_t);
 
 /* End of spa.h */

--- a/src/src/auths/xtextencode.c
+++ b/src/src/auths/xtextencode.c
@@ -31,7 +31,7 @@ uschar *code;
 uschar *p = (uschar *)clear;
 uschar *pp;
 int c = len;
-int count = 1;
+size_t count = 1;
 register int x;
 
 /* We have to do a prepass to find out how many specials there are,

--- a/src/src/daemon.c
+++ b/src/src/daemon.c
@@ -143,8 +143,8 @@ union sockaddr_46 interface_sockaddr;
 EXIM_SOCKLEN_T ifsize = sizeof(interface_sockaddr);
 int dup_accept_socket = -1;
 int max_for_this_host = 0;
-int wfsize = 0;
-int wfptr = 0;
+size_t wfsize = 0;
+size_t wfptr = 0;
 int save_log_selector = *log_selector;
 uschar *whofrom = NULL;
 
@@ -1065,10 +1065,10 @@ if (daemon_listen && !inetd_wait_mode)
     {
     uschar *new_smtp_port = NULL;
     uschar *new_local_interfaces = NULL;
-    int portsize = 0;
-    int portptr = 0;
-    int ifacesize = 0;
-    int ifaceptr = 0;
+    size_t portsize = 0;
+    size_t portptr = 0;
+    size_t ifacesize = 0;
+    size_t ifaceptr = 0;
 
     if (override_pid_file_path == NULL) write_pid = FALSE;
 
@@ -1078,8 +1078,8 @@ if (daemon_listen && !inetd_wait_mode)
       {
       uschar joinstr[4];
       uschar **ptr;
-      int *sizeptr;
-      int *ptrptr;
+      size_t *sizeptr;
+      size_t *ptrptr;
 
       if (Ustrpbrk(s, ".:") == NULL)
         {

--- a/src/src/dbfn.c
+++ b/src/src/dbfn.c
@@ -294,11 +294,11 @@ Returns: a pointer to the retrieved record, or
 */
 
 void *
-dbfn_read_with_length(open_db *dbblock, const uschar *key, int *length)
+dbfn_read_with_length(open_db *dbblock, const uschar *key, size_t *length)
 {
 void *yield;
 EXIM_DATUM key_datum, result_datum;
-int klen = Ustrlen(key) + 1;
+size_t klen = Ustrlen(key) + 1;
 uschar * key_copy = store_get(klen);
 
 memcpy(key_copy, key, klen);
@@ -338,11 +338,11 @@ Returns:    the yield of the underlying dbm or db "write" function. If this
 */
 
 int
-dbfn_write(open_db *dbblock, const uschar *key, void *ptr, int length)
+dbfn_write(open_db *dbblock, const uschar *key, void *ptr, size_t length)
 {
 EXIM_DATUM key_datum, value_datum;
 dbdata_generic *gptr = (dbdata_generic *)ptr;
-int klen = Ustrlen(key) + 1;
+size_t klen = Ustrlen(key) + 1;
 uschar * key_copy = store_get(klen);
 
 memcpy(key_copy, key, klen);
@@ -376,7 +376,7 @@ Returns: the yield of the underlying dbm or db "delete" function.
 int
 dbfn_delete(open_db *dbblock, const uschar *key)
 {
-int klen = Ustrlen(key) + 1;
+size_t klen = Ustrlen(key) + 1;
 uschar * key_copy = store_get(klen);
 
 memcpy(key_copy, key, klen);

--- a/src/src/dbfunctions.h
+++ b/src/src/dbfunctions.h
@@ -11,9 +11,9 @@
 void     dbfn_close(open_db *);
 int      dbfn_delete(open_db *, const uschar *);
 open_db *dbfn_open(uschar *, int, open_db *, BOOL);
-void    *dbfn_read_with_length(open_db *, const uschar *, int *);
+void    *dbfn_read_with_length(open_db *, const uschar *, size_t *);
 uschar  *dbfn_scan(open_db *, BOOL, EXIM_CURSOR **);
-int      dbfn_write(open_db *, const uschar *, void *, int);
+int      dbfn_write(open_db *, const uschar *, void *, size_t);
 
 /* Macro for the common call to read without wanting to know the length. */
 

--- a/src/src/deliver.c
+++ b/src/src/deliver.c
@@ -694,7 +694,7 @@ Returns:    New value for s
 */
 
 static uschar *
-d_log_interface(uschar *s, int *sizep, int *ptrp)
+d_log_interface(uschar *s, size_t *sizep, size_t *ptrp)
 {
 if (LOGGING(incoming_interface) && LOGGING(outgoing_interface)
     && sending_ip_address)
@@ -711,7 +711,7 @@ return s;
 
 
 static uschar *
-d_hostlog(uschar *s, int *sizep, int *ptrp, address_item *addr)
+d_hostlog(uschar *s, size_t *sizep, size_t *ptrp, address_item *addr)
 {
 s = string_append(s, sizep, ptrp, 5, US" H=", addr->host_used->name,
   US" [", addr->host_used->address, US"]");
@@ -738,7 +738,7 @@ return d_log_interface(s, sizep, ptrp);
 
 #ifdef SUPPORT_TLS
 static uschar *
-d_tlslog(uschar * s, int * sizep, int * ptrp, address_item * addr)
+d_tlslog(uschar * s, size_t * sizep, size_t * ptrp, address_item * addr)
 {
 if (LOGGING(tls_cipher) && addr->cipher)
   s = string_append(s, sizep, ptrp, 2, US" X=", addr->cipher);
@@ -844,8 +844,8 @@ void
 delivery_log(int flags, address_item * addr, int logchar, uschar * msg)
 {
 uschar *log_address;
-int size = 256;         /* Used for a temporary, */
-int ptr = 0;            /* expanding buffer, for */
+size_t size = 256;         /* Used for a temporary, */
+size_t ptr = 0;            /* expanding buffer, for */
 uschar *s;              /* building log lines;   */
 void *reset_point;      /* released afterwards.  */
 
@@ -1035,8 +1035,8 @@ uschar *driver_kind = NULL;
 uschar *driver_name = NULL;
 uschar *log_address;
 
-int size = 256;         /* Used for a temporary, */
-int ptr = 0;            /* expanding buffer, for */
+size_t size = 256;         /* Used for a temporary, */
+size_t ptr = 0;            /* expanding buffer, for */
 uschar *s;              /* building log lines;   */
 void *reset_point;      /* released afterwards.  */
 
@@ -1784,7 +1784,7 @@ Returns:      TRUE  the header is in the string
 static BOOL
 contains_header(uschar *hdr, uschar *hstring)
 {
-int len = Ustrlen(hdr);
+size_t len = Ustrlen(hdr);
 uschar *p = hstring;
 while (*p != 0)
   {
@@ -2152,7 +2152,7 @@ if ((pid = fork()) == 0)
 
     for (i = 0, s = addr2->message; i < 2; i++, s = addr2->user_message)
       {
-      int message_length = s ? Ustrlen(s) + 1 : 0;
+      size_t message_length = s ? Ustrlen(s) + 1 : 0;
       if(  (ret = write(pfd[pipe_write], &message_length, sizeof(int))) != sizeof(int)
         || message_length > 0  && (ret = write(pfd[pipe_write], s, message_length)) != message_length
 	)
@@ -4818,8 +4818,8 @@ Returns:     NULL or an expanded string
 static uschar *
 next_emf(FILE *f, uschar *which)
 {
-int size = 256;
-int ptr = 0;
+size_t size = 256;
+size_t ptr = 0;
 uschar *para, *yield;
 uschar buffer[256];
 
@@ -4980,7 +4980,7 @@ Returns:       nothing
 static void
 print_address_error(address_item *addr, FILE *f, uschar *t)
 {
-int count = Ustrlen(t);
+size_t count = Ustrlen(t);
 uschar *s = testflag(addr, af_pass_message)? addr->message : NULL;
 
 if (!s && !(s = addr->user_message))
@@ -7352,7 +7352,6 @@ wording. */
 	    addr->address);
         if ((hu = addr->host_used) && hu->name)
 	  {
-	  const uschar * s;
 	  fprintf(f, "Remote-MTA: dns; %s\n", hu->name);
 #ifdef EXPERIMENTAL_DSN_INFO
 	  if (hu->address)

--- a/src/src/dkim.c
+++ b/src/src/dkim.c
@@ -107,8 +107,8 @@ void
 dkim_exim_verify_finish(void)
 {
 pdkim_signature *sig = NULL;
-int dkim_signers_size = 0;
-int dkim_signers_ptr = 0;
+size_t dkim_signers_size = 0;
+size_t dkim_signers_ptr = 0;
 dkim_signers = NULL;
 
 store_pool = POOL_PERM;
@@ -139,8 +139,8 @@ if (pdkim_feed_finish(dkim_verify_ctx, &dkim_signatures) != PDKIM_OK)
 
 for (sig = dkim_signatures; sig; sig = sig->next)
   {
-  int size = 0;
-  int ptr = 0;
+  size_t size = 0;
+  size_t ptr = 0;
 
   /* Log a line for each signature */
 
@@ -440,8 +440,8 @@ dkim_exim_sign(int dkim_fd, uschar * dkim_private_key,
 {
 int sep = 0;
 uschar *seen_items = NULL;
-int seen_items_size = 0;
-int seen_items_offset = 0;
+size_t seen_items_size = 0;
+size_t seen_items_offset = 0;
 uschar itembuf[256];
 uschar *dkim_canon_expanded;
 uschar *dkim_sign_headers_expanded;
@@ -449,8 +449,8 @@ uschar *dkim_private_key_expanded;
 pdkim_ctx *ctx = NULL;
 uschar *rc = NULL;
 uschar *sigbuf = NULL;
-int sigsize = 0;
-int sigptr = 0;
+size_t sigsize = 0;
+size_t sigptr = 0;
 pdkim_signature *signature;
 int pdkim_canon;
 int pdkim_rc;

--- a/src/src/dmarc.c
+++ b/src/src/dmarc.c
@@ -182,7 +182,7 @@ if (!from_header || dmarc_abort)
 else
   {
     uschar * errormsg;
-    int dummy, domain;
+    size_t dummy, domain;
     uschar * p;
     uschar saveend;
 

--- a/src/src/dummies.c
+++ b/src/src/dummies.c
@@ -20,7 +20,7 @@ alternates. */
 /* We don't have the full Exim headers dragged in, but this function
 is used for debugging output. */
 
-extern int  string_vformat(char *, int, char *, va_list);
+extern int  string_vformat(char *, size_t, char *, va_list);
 
 
 /*************************************************
@@ -76,8 +76,8 @@ va_start(ap, format);
 if (!string_vformat(buffer, sizeof(buffer), format, ap))
   {
   char *s = "**** debug string overflowed buffer ****\n";
-  char *p = buffer + (int)strlen(buffer);
-  int maxlen = sizeof(buffer) - (int)strlen(s) - 3;
+  char *p = buffer + strlen(buffer);
+  size_t maxlen = sizeof(buffer) - strlen(s) - 3;
   if (p > buffer + maxlen) p = buffer + maxlen;
   if (p > buffer && p[-1] != '\n') *p++ = '\n';
   strcpy(p, s);

--- a/src/src/exim.c
+++ b/src/src/exim.c
@@ -38,7 +38,7 @@ regular expression for a long time; the other for short-term use. */
 static void *
 function_store_get(size_t size)
 {
-return store_get((int)size);
+return store_get(size);
 }
 
 static void
@@ -717,7 +717,8 @@ Returns:       nothing
 static void
 test_address(uschar *s, int flags, int *exit_value)
 {
-int start, end, domain;
+size_t start, end;
+int domain;
 uschar *parse_error = NULL;
 uschar *address = parse_extract_address(s, &parse_error, &start, &end, &domain,
   FALSE);
@@ -1123,7 +1124,7 @@ uschar *
 local_part_quote(uschar *lpart)
 {
 BOOL needs_quote = FALSE;
-int size, ptr;
+size_t size, ptr;
 uschar *yield;
 uschar *t;
 
@@ -1227,8 +1228,8 @@ static uschar *
 get_stdinput(char *(*fn_readline)(const char *), void(*fn_addhist)(const char *))
 {
 int i;
-int size = 0;
-int ptr = 0;
+size_t size = 0;
+size_t ptr = 0;
 uschar *yield = NULL;
 
 if (fn_readline == NULL) { printf("> "); fflush(stdout); }
@@ -1258,7 +1259,7 @@ for (i = 0;; i++)
 
   /* Handle the line */
 
-  ss = p + (int)Ustrlen(p);
+  ss = p + Ustrlen(p);
   while (ss > p && isspace(ss[-1])) ss--;
 
   if (i > 0)
@@ -2546,7 +2547,7 @@ for (i = 1; i < argc; i++)
 
     case 'f':
       {
-      int dummy_start, dummy_end;
+      size_t dummy_start, dummy_end;
       uschar *errmess;
       if (*argrest == 0)
         {
@@ -5432,7 +5433,8 @@ while (more)
 
     for (i = 0; i < count; i++)
       {
-      int start, end, domain;
+      size_t start, end;
+      int domain;
       uschar *errmess;
       uschar *s = list[i];
 

--- a/src/src/exim_dbutil.c
+++ b/src/src/exim_dbutil.c
@@ -357,11 +357,11 @@ Returns: a pointer to the retrieved record, or
 */
 
 void *
-dbfn_read_with_length(open_db *dbblock, const uschar *key, int *length)
+dbfn_read_with_length(open_db *dbblock, const uschar *key, size_t *length)
 {
 void *yield;
 EXIM_DATUM key_datum, result_datum;
-int klen = Ustrlen(key) + 1;
+size_t klen = Ustrlen(key) + 1;
 uschar * key_copy = store_get(klen);
 
 memcpy(key_copy, key, klen);
@@ -401,11 +401,11 @@ Returns:    the yield of the underlying dbm or db "write" function. If this
 */
 
 int
-dbfn_write(open_db *dbblock, const uschar *key, void *ptr, int length)
+dbfn_write(open_db *dbblock, const uschar *key, void *ptr, size_t length)
 {
 EXIM_DATUM key_datum, value_datum;
 dbdata_generic *gptr = (dbdata_generic *)ptr;
-int klen = Ustrlen(key) + 1;
+size_t klen = Ustrlen(key) + 1;
 uschar * key_copy = store_get(klen);
 
 memcpy(key_copy, key, klen);
@@ -437,7 +437,7 @@ Returns: the yield of the underlying dbm or db "delete" function.
 int
 dbfn_delete(open_db *dbblock, const uschar *key)
 {
-int klen = Ustrlen(key) + 1;
+size_t klen = Ustrlen(key) + 1;
 uschar * key_copy = store_get(klen);
 
 memcpy(key_copy, key, klen);
@@ -531,8 +531,8 @@ while (key != NULL)
   dbdata_callout_cache *callout;
   dbdata_ratelimit *ratelimit;
   dbdata_ratelimit_unique *rate_unique;
-  int count_bad = 0;
-  int i, length;
+  int i, count_bad = 0;
+  size_t length;
   uschar *t;
   uschar name[MESSAGE_ID_LENGTH + 1];
   void *value;
@@ -738,7 +738,8 @@ for(;;)
   dbdata_callout_cache *callout;
   dbdata_ratelimit *ratelimit;
   dbdata_ratelimit_unique *rate_unique;
-  int i, oldlength;
+  int i;
+  size_t oldlength;
   uschar *t;
   uschar field[256], value[256];
 
@@ -1318,7 +1319,7 @@ while (keychain != NULL)
   else if (dbdata_type == type_retry)
     {
     uschar *id;
-    int len = Ustrlen(key);
+    size_t len = Ustrlen(key);
 
     if (len < MESSAGE_ID_LENGTH + 1) continue;
     id = key + len - MESSAGE_ID_LENGTH - 1;

--- a/src/src/exim_lock.c
+++ b/src/src/exim_lock.c
@@ -274,7 +274,7 @@ if (*filename == '~')
     exit(1);
     }
 
-  if ((int)strlen(pw->pw_dir) + (int)strlen(filename) + 1 > sizeof(buffer))
+  if (strlen(pw->pw_dir) + strlen(filename) + 1 > sizeof(buffer))
     {
     printf("exim_lock: expanded file name %s%s is too long", pw->pw_dir,
       filename);

--- a/src/src/expand.c
+++ b/src/src/expand.c
@@ -1039,7 +1039,7 @@ Returns:    a pointer to the first character after the header name
 */
 
 static const uschar *
-read_header_name(uschar *name, int max, const uschar *s)
+read_header_name(uschar *name, size_t max, const uschar *s)
 {
 int prelen = Ustrchr(name, '_') - name + 1;
 int ptr = Ustrlen(name) - prelen;
@@ -1105,7 +1105,7 @@ Returns:    NULL if the subfield was not found, or
 static uschar *
 expand_getkeyed(uschar *key, const uschar *s)
 {
-int length = Ustrlen(key);
+size_t length = Ustrlen(key);
 while (isspace(*s)) s++;
 
 /* Loop to search for the key */
@@ -1328,9 +1328,9 @@ Returns:      pointer to the output string, or NULL if there is an error
 */
 
 static uschar *
-extract_substr(uschar *subject, int value1, int value2, int *len)
+extract_substr(uschar *subject, int value1, int value2, size_t *len)
 {
-int sublen = Ustrlen(subject);
+size_t sublen = Ustrlen(subject);
 
 if (value1 < 0)    /* count from right */
   {
@@ -1399,9 +1399,9 @@ Returns:      pointer to the output string, or NULL if there is an error
 */
 
 static uschar *
-compute_hash(uschar *subject, int value1, int value2, int *len)
+compute_hash(uschar *subject, int value1, int value2, size_t *len)
 {
-int sublen = Ustrlen(subject);
+size_t sublen = Ustrlen(subject);
 
 if (value2 < 0) value2 = 26;
 else if (value2 > Ustrlen(hashcodes))
@@ -1456,7 +1456,7 @@ Returns:  pointer to the output string, or NULL if there is an error.
 */
 
 static uschar *
-compute_nhash (uschar *subject, int value1, int value2, int *len)
+compute_nhash (uschar *subject, int value1, int value2, size_t *len)
 {
 uschar *s = subject;
 int i = 0;
@@ -1525,12 +1525,12 @@ Returns:        NULL if the header does not exist, else a pointer to a new
 */
 
 static uschar *
-find_header(uschar *name, BOOL exists_only, int *newsize, BOOL want_raw,
+find_header(uschar *name, BOOL exists_only, size_t *newsize, BOOL want_raw,
   uschar *charset)
 {
 BOOL found = name == NULL;
 int comma = 0;
-int len = found? 0 : Ustrlen(name);
+size_t len = found? 0 : Ustrlen(name);
 int i;
 uschar *yield = NULL;
 uschar *ptr = NULL;
@@ -1539,7 +1539,7 @@ uschar *ptr = NULL;
 
 for (i = 0; i < 2; i++)
   {
-  int size = 0;
+  size_t size = 0;
   header_line *h;
 
   for (h = header_list; size < header_insert_maxlen && h != NULL; h = h->next)
@@ -1663,8 +1663,8 @@ fn_recipients(void)
 {
 if (!enable_dollar_recipients) return NULL; else
   {
-  int size = 128;
-  int ptr = 0;
+  size_t size = 128;
+  size_t ptr = 0;
   int i;
   uschar * s = store_get(size);
   for (i = 0; i < recipients_count; i++)
@@ -1701,7 +1701,7 @@ Returns:        NULL if the variable does not exist, or
 */
 
 static uschar *
-find_variable(uschar *name, BOOL exists_only, BOOL skipping, int *newsize)
+find_variable(uschar *name, BOOL exists_only, BOOL skipping, size_t *newsize)
 {
 var_entry * vp;
 uschar *s, *domain;
@@ -2356,8 +2356,8 @@ switch(cond_type)
     uschar *sub[10];
     uschar *user_msg;
     BOOL cond = FALSE;
-    int size = 0;
-    int ptr = 0;
+    size_t size = 0;
+    size_t ptr = 0;
 
     while (isspace(*s)) s++;
     if (*s++ != '{') goto COND_FAILED_CURLY_START;	/*}*/
@@ -2681,7 +2681,7 @@ switch(cond_type)
     #else
     if (strncmpic(sub[1], US"{md5}", 5) == 0)
       {
-      int sublen = Ustrlen(sub[1]+5);
+      size_t sublen = Ustrlen(sub[1]+5);
       md5 base;
       uschar digest[16];
 
@@ -2720,7 +2720,7 @@ switch(cond_type)
 
     else if (strncmpic(sub[1], US"{sha1}", 6) == 0)
       {
-      int sublen = Ustrlen(sub[1]+6);
+      size_t sublen = Ustrlen(sub[1]+6);
       sha1 base;
       uschar digest[20];
 
@@ -3166,7 +3166,7 @@ Returns:         0 OK; lookup_value has been reset to save_lookup
 
 static int
 process_yesno(BOOL skipping, BOOL yes, uschar *save_lookup, const uschar **sptr,
-  uschar **yieldptr, int *sizeptr, int *ptrptr, uschar *type, BOOL *resetok)
+  uschar **yieldptr, size_t *sizeptr, size_t *ptrptr, uschar *type, BOOL *resetok)
 {
 int rc = 0;
 const uschar *s = *sptr;    /* Local value */
@@ -3414,7 +3414,8 @@ static uschar *
 prvs_hmac_sha1(uschar *address, uschar *key, uschar *key_num, uschar *daystamp)
 {
 uschar *hash_source, *p;
-int size = 0,offset = 0,i;
+size_t size = 0,offset = 0;
+int i;
 sha1 sha1_base;
 void *use_base = &sha1_base;
 uschar innerhash[20];
@@ -3486,14 +3487,14 @@ Returns:       new value of string pointer
 */
 
 static uschar *
-cat_file(FILE *f, uschar *yield, int *sizep, int *ptrp, uschar *eol)
+cat_file(FILE *f, uschar *yield, size_t *sizep, size_t *ptrp, uschar *eol)
 {
-int eollen = eol ? Ustrlen(eol) : 0;
+size_t eollen = eol ? Ustrlen(eol) : 0;
 uschar buffer[1024];
 
 while (Ufgets(buffer, sizeof(buffer), f))
   {
-  int len = Ustrlen(buffer);
+  size_t len = Ustrlen(buffer);
   if (eol && buffer[len-1] == '\n') len--;
   yield = string_catn(yield, sizep, ptrp, buffer, len);
   if (buffer[len] != 0)
@@ -3849,8 +3850,8 @@ static uschar *
 expand_string_internal(const uschar *string, BOOL ket_ends, const uschar **left,
   BOOL skipping, BOOL honour_dollar, BOOL *resetok_p)
 {
-int ptr = 0;
-int size = Ustrlen(string)+ 64;
+size_t ptr = 0;
+size_t size = Ustrlen(string)+ 64;
 uschar *yield = store_get(size);
 int item_type;
 const uschar *s = string;
@@ -3924,8 +3925,7 @@ while (*s != 0)
 
   if (isalpha((*(++s))))
     {
-    int len;
-    int newsize = 0;
+    size_t len, newsize = 0;
 
     s = read_name(name, sizeof(name), s, US"_");
 
@@ -4524,7 +4524,7 @@ while (*s != 0)
     case EITEM_PRVSCHECK:
       {
       uschar *sub_arg[3];
-      int mysize = 0, myptr = 0;
+      size_t mysize = 0, myptr = 0;
       const pcre *re;
       uschar *p;
 
@@ -4928,7 +4928,7 @@ while (*s != 0)
       const uschar **argv;
       pid_t pid;
       int fd_in, fd_out;
-      int lsize = 0, lptr = 0;
+      size_t lsize = 0, lptr = 0;
 
       if ((expand_forbid & RDO_RUN) != 0)
         {
@@ -5074,7 +5074,7 @@ while (*s != 0)
     case EITEM_SUBSTR:
       {
       int i;
-      int len;
+      size_t len;
       uschar *ret;
       int val[2] = { 0, -1 };
       uschar *sub[3];
@@ -6311,7 +6311,7 @@ while (*s != 0)
 
       case EOP_LC:
         {
-        int count = 0;
+        size_t count = 0;
         uschar *t = sub - 1;
         while (*(++t) != 0) { *t = tolower(*t); count++; }
         yield = string_catn(yield, &size, &ptr, sub, count);
@@ -6320,7 +6320,7 @@ while (*s != 0)
 
       case EOP_UC:
         {
-        int count = 0;
+        size_t count = 0;
         uschar *t = sub - 1;
         while (*(++t) != 0) { *t = toupper(*t); count++; }
         yield = string_catn(yield, &size, &ptr, sub, count);
@@ -6631,7 +6631,8 @@ while (*s != 0)
       case EOP_DOMAIN:
         {
         uschar *error;
-        int start, end, domain;
+        size_t start, end;
+        int domain;
         uschar *t = parse_extract_address(sub, &error, &start, &end, &domain,
           FALSE);
         if (t != NULL)
@@ -6654,8 +6655,8 @@ while (*s != 0)
         {
         uschar outsep[2] = { ':', '\0' };
         uschar *address, *error;
-        int save_ptr = ptr;
-        int start, end, domain;  /* Not really used */
+        int domain, save_ptr = ptr;
+        size_t start, end;
 
         while (isspace(*sub)) sub++;
         if (*sub == '>') { *outsep = *++sub; ++sub; }
@@ -6828,7 +6829,7 @@ while (*s != 0)
 
       case EOP_RFC2047D:
         {
-        int len;
+        size_t len;
         uschar *error;
         uschar *decoded = rfc2047_decode(sub, check_rfc2047_length,
           headers_charset, '?', &len, &error);
@@ -6864,8 +6865,8 @@ while (*s != 0)
 
       case EOP_UTF8CLEAN:
         {
-        int seq_len = 0, index = 0;
-        int bytes_left = 0;
+        size_t seq_len = 0;
+        int index = 0, bytes_left = 0;
 	long codepoint = -1;
         uschar seq_buff[4];			/* accumulate utf-8 here */
 
@@ -7130,7 +7131,7 @@ while (*s != 0)
         int value1 = 0;
         int value2 = -1;
         int *pn;
-        int len;
+        size_t len;
         uschar *ret;
 
         if (arg == NULL)
@@ -7300,8 +7301,8 @@ while (*s != 0)
 						/*{*/
   if (*s++ == '}')
     {
-    int len;
-    int newsize = 0;
+    size_t len;
+    size_t newsize = 0;
     if (ptr == 0)
       {
       if (resetok) store_reset(yield);

--- a/src/src/filter.c
+++ b/src/src/filter.c
@@ -1507,8 +1507,8 @@ switch (c->type)
   while (*pp != 0)
     {
     uschar *error;
-    int start, end, domain;
-    int saveend;
+    size_t start, end;
+    int saveend, domain;
 
     p = parse_find_address_end(pp, FALSE);
     saveend = *p;
@@ -1758,7 +1758,8 @@ while (commands != NULL)
       s = expargs[i];
       if (s != NULL)
         {
-        int start, end, domain;
+        size_t start, end;
+        int domain;
         uschar *error;
         uschar *ss = parse_extract_address(s, &error, &start, &end, &domain,
           FALSE);
@@ -2226,8 +2227,8 @@ while (commands != NULL)
       uschar *tt;
       uschar *log_addr = NULL;
       uschar *to = commands->args[mailarg_index_to].u;
-      int size = 0;
-      int ptr = 0;
+      size_t size = 0;
+      size_t ptr = 0;
       int badflag = 0;
 
       if (to == NULL) to = expand_string(US"$reply_address");
@@ -2268,8 +2269,8 @@ while (commands != NULL)
         {
         uschar *ss = parse_find_address_end(tt, FALSE);
         uschar *recipient, *errmess;
-        int start, end, domain;
-        int temp = *ss;
+        size_t start, end;
+        int domain, temp = *ss;
 
         *ss = 0;
         recipient = parse_extract_address(tt, &errmess, &start, &end, &domain,

--- a/src/src/filtertest.c
+++ b/src/src/filtertest.c
@@ -108,8 +108,8 @@ wrapped round in message_body_end. */
 
 if (body_len >= message_body_visible)
   {
-  int below = s - message_body_end;
-  int above = message_body_visible - below;
+  size_t below = s - message_body_end;
+  size_t above = message_body_visible - below;
   if (above > 0)
     {
     uschar *temp = store_get(below);

--- a/src/src/functions.h
+++ b/src/src/functions.h
@@ -281,15 +281,15 @@ extern FILE   *modefopen(const uschar *, const char *, mode_t);
 
 extern int     open_cutthrough_connection( address_item * addr );
 
-extern uschar *parse_extract_address(uschar *, uschar **, int *, int *, int *,
+extern uschar *parse_extract_address(uschar *, uschar **, size_t *, size_t *, int *,
                  BOOL);
 extern int     parse_forward_list(uschar *, int, address_item **, uschar **,
                  const uschar *, uschar *, error_block **);
 extern uschar *parse_find_address_end(uschar *, BOOL);
 extern uschar *parse_find_at(uschar *);
-extern const uschar *parse_fix_phrase(const uschar *, int, uschar *, int);
+extern const uschar *parse_fix_phrase(const uschar *, size_t, uschar *, size_t);
 extern uschar *parse_message_id(uschar *, uschar **, uschar **);
-extern const uschar *parse_quote_2047(const uschar *, int, uschar *, uschar *, int, BOOL);
+extern const uschar *parse_quote_2047(const uschar *, size_t, uschar *, uschar *, size_t, BOOL);
 extern uschar *parse_date_time(uschar *str, time_t *t);
 extern int     vaguely_random_number(int);
 #ifdef SUPPORT_TLS
@@ -346,7 +346,7 @@ extern header_line *rewrite_header(header_line *,
 extern uschar *rewrite_one(uschar *, int, BOOL *, BOOL, uschar *,
                  rewrite_rule *);
 extern void    rewrite_test(uschar *);
-extern uschar *rfc2047_decode2(uschar *, BOOL, uschar *, int, int *, int *,
+extern uschar *rfc2047_decode2(uschar *, BOOL, uschar *, int, size_t *, size_t *,
                  uschar **);
 extern int     route_address(address_item *, address_item **, address_item **,
                  address_item **, address_item **, int);
@@ -413,20 +413,20 @@ extern int     stdin_getc(void);
 extern int     stdin_feof(void);
 extern int     stdin_ferror(void);
 extern int     stdin_ungetc(int);
-extern uschar *string_append(uschar *, int *, int *, int, ...);
+extern uschar *string_append(uschar *, size_t *, size_t *, int, ...);
 extern uschar *string_append_listele(uschar *, uschar, const uschar *);
-extern uschar *string_append_listele_n(uschar *, uschar, const uschar *, unsigned);
+extern uschar *string_append_listele_n(uschar *, uschar, const uschar *, size_t);
 extern uschar *string_base62(unsigned long int);
-extern uschar *string_cat(uschar *, int *, int *, const uschar *);
-extern uschar *string_catn(uschar *, int *, int *, const uschar *, int);
+extern uschar *string_cat(uschar *, size_t *, size_t *, const uschar *);
+extern uschar *string_catn(uschar *, size_t *, size_t *, const uschar *, size_t);
 extern int     string_compare_by_pointer(const void *, const void *);
 extern uschar *string_copy_dnsdomain(uschar *);
 extern uschar *string_copy_malloc(const uschar *);
 extern uschar *string_copylc(const uschar *);
-extern uschar *string_copynlc(uschar *, int);
+extern uschar *string_copynlc(uschar *, size_t);
 extern uschar *string_dequote(const uschar **);
-extern BOOL    string_format(uschar *, int, const char *, ...) ALMOST_PRINTF(3,4);
-extern uschar *string_format_size(int, uschar *);
+extern BOOL    string_format(uschar *, size_t, const char *, ...) ALMOST_PRINTF(3,4);
+extern uschar *string_format_size(size_t, uschar *);
 extern int     string_interpret_escape(const uschar **);
 extern int     string_is_ip_address(const uschar *, int *);
 #ifdef SUPPORT_I18N
@@ -445,9 +445,9 @@ extern uschar *string_domain_utf8_to_alabel(const uschar *, uschar **);
 extern uschar *string_localpart_alabel_to_utf8(const uschar *, uschar **);
 extern uschar *string_localpart_utf8_to_alabel(const uschar *, uschar **);
 #endif
-extern BOOL    string_vformat(uschar *, int, const char *, va_list);
+extern BOOL    string_vformat(uschar *, size_t, const char *, va_list);
 extern int     strcmpic(const uschar *, const uschar *);
-extern int     strncmpic(const uschar *, const uschar *, int);
+extern int     strncmpic(const uschar *, const uschar *, size_t);
 extern uschar *strstric(uschar *, uschar *, BOOL);
 
 extern uschar *tod_stamp(int);

--- a/src/src/globals.c
+++ b/src/src/globals.c
@@ -703,7 +703,7 @@ uschar *exim_path              = US BIN_DIRECTORY "/exim"
 uid_t   exim_uid               = EXIM_UID;
 BOOL    exim_uid_set           = TRUE;          /* This uid is always set */
 int     expand_forbid          = 0;
-int     expand_nlength[EXPAND_MAXN+1];
+size_t     expand_nlength[EXPAND_MAXN+1];
 int     expand_nmax            = -1;
 uschar *expand_nstring[EXPAND_MAXN+1];
 BOOL    expand_string_forcedfail = FALSE;

--- a/src/src/globals.h
+++ b/src/src/globals.h
@@ -443,7 +443,7 @@ extern const uschar *exim_sieve_extension_list[]; /* list of sieve extensions */
 extern uid_t   exim_uid;               /* Non-root uid for exim */
 extern BOOL    exim_uid_set;           /* TRUE if exim_uid set */
 extern int     expand_forbid;          /* RDO flags for forbidding things */
-extern int     expand_nlength[];       /* Lengths of numbered strings */
+extern size_t     expand_nlength[];       /* Lengths of numbered strings */
 extern int     expand_nmax;            /* Max numerical value */
 extern uschar *expand_nstring[];       /* Numbered strings */
 extern BOOL    expand_string_forcedfail; /* TRUE if failure was "expected" */

--- a/src/src/header.c
+++ b/src/src/header.c
@@ -28,7 +28,7 @@ Returns:    TRUE or FALSE
 */
 
 BOOL
-header_testname(header_line *h, const uschar *name, int len, BOOL notdel)
+header_testname(header_line *h, const uschar *name, size_t len, BOOL notdel)
 {
 uschar *tt;
 if (h->type == '*' && notdel) return FALSE;
@@ -45,7 +45,7 @@ return *tt == ':';
 
 BOOL
 header_testname_incomplete(header_line *h, const uschar *name,
-    int len, BOOL notdel)
+    size_t len, BOOL notdel)
 {
 if (h->type == '*' && notdel) return FALSE;
 if (h->text == NULL || strncmpic(h->text, name, len) != 0) return FALSE;
@@ -130,7 +130,7 @@ if (name == NULL)
 
 else
   {
-  int len = Ustrlen(name);
+  size_t len = Ustrlen(name);
 
   /* Find the first non-deleted header witht the correct name. */
 
@@ -267,7 +267,7 @@ header_remove(int occ, const uschar *name)
 {
 header_line *h;
 int hcount = 0;
-int len = Ustrlen(name);
+size_t len = Ustrlen(name);
 for (h = header_list; h != NULL; h = h->next)
   {
   if (header_testname(h, name, len, TRUE) && (occ <= 0 || ++hcount == occ))
@@ -356,7 +356,7 @@ Returns:         cond if the header exists and contains one of the strings;
 /* First we have a local subroutine to handle a single pattern */
 
 static BOOL
-one_pattern_match(uschar *name, int slen, BOOL has_addresses, uschar *pattern)
+one_pattern_match(uschar *name, size_t slen, BOOL has_addresses, uschar *pattern)
 {
 BOOL yield = FALSE;
 header_line *h;
@@ -386,8 +386,8 @@ for (h = header_list; !yield && h != NULL; h = h->next)
       {
       uschar *error, *next;
       uschar *e = parse_find_address_end(s, FALSE);
-      int terminator = *e;
-      int start, end, domain;
+      int domain, terminator = *e;
+      size_t start, end;
 
       /* Temporarily terminate the string at the address end while extracting
       the operative address within. */
@@ -441,7 +441,7 @@ header_match(uschar *name, BOOL has_addresses, BOOL cond, string_item *strings,
 va_list ap;
 string_item *s;
 int i;
-int slen = Ustrlen(name);
+size_t slen = Ustrlen(name);
 
 for (s = strings; s != NULL; s = s->next)
   {

--- a/src/src/host.c
+++ b/src/src/host.c
@@ -167,9 +167,9 @@ static struct hostent *
 host_fake_gethostbyname(const uschar *name, int af, int *error_num)
 {
 #if HAVE_IPV6
-int alen = (af == AF_INET)? sizeof(struct in_addr):sizeof(struct in6_addr);
+size_t alen = (af == AF_INET)? sizeof(struct in_addr):sizeof(struct in6_addr);
 #else
-int alen = sizeof(struct in_addr);
+size_t alen = sizeof(struct in_addr);
 #endif
 
 int ipa;
@@ -589,9 +589,9 @@ else if (sender_helo_name[0] == '[' &&
 if (sender_host_name == NULL)
   {
   uschar *portptr = Ustrstr(address, "]:");
-  int size = 0;
-  int ptr = 0;
-  int adlen;    /* Sun compiler doesn't like ++ in initializers */
+  size_t size = 0;
+  size_t ptr = 0;
+  size_t adlen;    /* Sun compiler doesn't like ++ in initializers */
 
   adlen = (portptr == NULL)? Ustrlen(address) : (++portptr - address);
   sender_fullhost = (sender_helo_name == NULL)? address :
@@ -1517,7 +1517,7 @@ Returns:     OK, DEFER, FAIL
 static int
 host_name_lookup_byaddr(void)
 {
-int len;
+size_t len;
 uschar *s, *t;
 struct hostent *hosts;
 struct in_addr addr;
@@ -1706,7 +1706,7 @@ while ((ordername = string_nextinlist(&list, &sep, buffer, sizeof(buffer))))
     if (rc == DNS_SUCCEED)
       {
       uschar **aptr = NULL;
-      int ssize = 264;
+      size_t ssize = 264;
       int count = 0;
       int old_pool = store_pool;
 

--- a/src/src/imap_utf7.c
+++ b/src/src/imap_utf7.c
@@ -8,8 +8,8 @@ imap_utf7_encode(uschar *string, const uschar *charset, uschar sep,
 {
 static uschar encode_base64[64] =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,";
-int ptr = 0;
-int size = 0;
+size_t ptr = 0;
+size_t size = 0;
 size_t slen;
 uschar *sptr, *yield = NULL;
 int i = 0, j;	/* compiler quietening */

--- a/src/src/ip.c
+++ b/src/src/ip.c
@@ -273,7 +273,8 @@ int
 ip_connectedsocket(int type, const uschar * hostname, int portlo, int porthi,
 	int timeout, host_item * connhost, uschar ** errstr)
 {
-int namelen, port;
+int port;
+size_t namelen;
 host_item shost;
 host_item *h;
 int af = 0, fd, fd4 = -1, fd6 = -1;

--- a/src/src/local_scan.h
+++ b/src/src/local_scan.h
@@ -173,8 +173,8 @@ extern uschar *expand_string(uschar *);
 extern void    header_add(int, const char *, ...);
 extern void    header_add_at_position(BOOL, uschar *, BOOL, int, const char *, ...);
 extern void    header_remove(int, const uschar *);
-extern BOOL    header_testname(header_line *, const uschar *, int, BOOL);
-extern BOOL    header_testname_incomplete(header_line *, const uschar *, int, BOOL);
+extern BOOL    header_testname(header_line *, const uschar *, size_t, BOOL);
+extern BOOL    header_testname_incomplete(header_line *, const uschar *, size_t, BOOL);
 extern void    log_write(unsigned int, int, const char *format, ...) PRINTF_FUNCTION(3,4);
 extern int     lss_b64decode(uschar *, uschar **);
 extern uschar *lss_b64encode(uschar *, int);
@@ -184,12 +184,12 @@ extern int     lss_match_address(uschar *, uschar *, BOOL);
 extern int     lss_match_host(uschar *, uschar *, uschar *);
 extern void    receive_add_recipient(uschar *, int);
 extern BOOL    receive_remove_recipient(uschar *);
-extern uschar *rfc2047_decode(uschar *, BOOL, uschar *, int, int *, uschar **);
+extern uschar *rfc2047_decode(uschar *, BOOL, uschar *, int, size_t *, uschar **);
 extern int     smtp_fflush(void);
 extern void    smtp_printf(const char *, ...) PRINTF_FUNCTION(1,2);
 extern void    smtp_vprintf(const char *, va_list);
 extern uschar *string_copy(const uschar *);
-extern uschar *string_copyn(const uschar *, int);
+extern uschar *string_copyn(const uschar *, size_t);
 extern uschar *string_sprintf(const char *, ...) ALMOST_PRINTF(1,2);
 
 /* End of local_scan.h */

--- a/src/src/lookups/dbmdb.c
+++ b/src/src/lookups/dbmdb.c
@@ -144,7 +144,8 @@ dbmjz_find(void *handle, uschar *filename, const uschar *keystring, int length,
 {
 uschar *key_item, *key_buffer, *key_p;
 const uschar *key_elems = keystring;
-int buflen, bufleft, key_item_len, sep = 0;
+size_t buflen, bufleft;
+int key_item_len, sep = 0;
 
 /* To a first approximation, the size of the lookup key needs to be about,
 or less than, the length of the delimited list passed in + 1. */

--- a/src/src/lookups/dnsdb.c
+++ b/src/src/lookups/dnsdb.c
@@ -134,8 +134,8 @@ dnsdb_find(void *handle, uschar *filename, const uschar *keystring, int length,
   uschar **result, uschar **errmsg, uint *do_cache)
 {
 int rc;
-int size = 256;
-int ptr = 0;
+size_t size = 256;
+size_t ptr = 0;
 int sep = 0;
 int defer_mode = PASS;
 int dnssec_mode = OK;
@@ -255,7 +255,8 @@ If the keystring contains an = this must be preceded by a valid type name. */
 type = T_TXT;
 if ((equals = Ustrchr(keystring, '=')) != NULL)
   {
-  int i, len;
+  int i;
+  size_t len;
   uschar *tend = equals;
 
   while (tend > keystring && isspace(tend[-1])) tend--;

--- a/src/src/lookups/ibase.c
+++ b/src/src/lookups/ibase.c
@@ -117,8 +117,8 @@ perform_ibase_search(uschar * query, uschar * server, uschar ** resultptr,
     ISC_STATUS status[20], *statusp = status;
 
     int i;
-    int ssize = 0;
-    int offset = 0;
+    size_t ssize = 0;
+    size_t offset = 0;
     int yield = DEFER;
     uschar *result = NULL;
     ibase_connection *cn;
@@ -367,7 +367,7 @@ has the password removed. This copy is also used for debugging output. */
 
         else
             for (i = 0; i < out_sqlda->sqld; i++) {
-                int len = fetch_field(buffer, sizeof(buffer),
+                size_t len = fetch_field(buffer, sizeof(buffer),
                                       &out_sqlda->sqlvar[i]);
 
                 result =

--- a/src/src/lookups/ldap.c
+++ b/src/src/lookups/ldap.c
@@ -161,9 +161,9 @@ int    error_yield = DEFER;
 int    msgid;
 int    rc, ldap_rc, ldap_parse_rc;
 int    port;
-int    ptr = 0;
+size_t    ptr = 0;
 int    rescount = 0;
-int    size = 0;
+size_t    size = 0;
 BOOL   attribute_found = FALSE;
 BOOL   ldapi = FALSE;
 
@@ -806,7 +806,7 @@ while ((rc = ldap_result(lcp->ld, msgid, 0, timeoutptr, &result)) ==
           while (*values != NULL)
             {
             uschar *value = *values;
-            int len = Ustrlen(value);
+            size_t len = Ustrlen(value);
             ++valuecount;
 
             DEBUG(D_lookup) debug_printf("LDAP value loop %s:%s\n", attr, value);
@@ -1169,7 +1169,7 @@ while (strncmpic(url, US"ldap", 4) != 0)
   while (*url != 0 && *url != '=') url++;
   if (*url == '=')
     {
-    int namelen;
+    size_t namelen;
     uschar *value;
     namelen = ++url - name;
     value = string_dequote(&url);

--- a/src/src/lookups/lf_functions.h
+++ b/src/src/lookups/lf_functions.h
@@ -9,7 +9,7 @@
 
 extern int     lf_check_file(int, uschar *, int, int, uid_t *, gid_t *,
                  const char *, uschar **);
-extern uschar *lf_quote(uschar *, uschar *, int, uschar *, int *, int *);
+extern uschar *lf_quote(uschar *, uschar *, size_t, uschar *, size_t *, size_t *);
 extern int     lf_sqlperform(const uschar *, const uschar *, const uschar *,
 		 const uschar *, uschar **,
                  uschar **, uint *, int(*)(const uschar *, uschar *, uschar **,

--- a/src/src/lookups/lf_quote.c
+++ b/src/src/lookups/lf_quote.c
@@ -30,8 +30,8 @@ Returns:         the result pointer (possibly updated)
 */
 
 uschar *
-lf_quote(uschar *name, uschar *value, int vlength, uschar *result, int *asize,
-  int *aoffset)
+lf_quote(uschar *name, uschar *value, size_t vlength, uschar *result, size_t *asize,
+  size_t *aoffset)
 {
 result = string_append(result, asize, aoffset, 2, name, US"=");
 

--- a/src/src/lookups/lf_sqlperform.c
+++ b/src/src/lookups/lf_sqlperform.c
@@ -108,7 +108,7 @@ else
       server = qserver;
     else
       {
-      int len = Ustrlen(qserver);
+      size_t len = Ustrlen(qserver);
 
       sep = 0;
       serverlist = optserverlist;

--- a/src/src/lookups/lsearch.c
+++ b/src/src/lookups/lsearch.c
@@ -72,7 +72,7 @@ but people do occasionally do weird things. */
 
 static int
 internal_lsearch_find(void *handle, uschar *filename, const uschar *keystring,
-  int length, uschar **result, uschar **errmsg, int type)
+  size_t length, uschar **result, uschar **errmsg, int type)
 {
 FILE *f = (FILE *)handle;
 BOOL last_was_eol = TRUE;
@@ -101,9 +101,8 @@ for (last_was_eol = TRUE;
      Ufgets(buffer, sizeof(buffer), f) != NULL;
      last_was_eol = this_is_eol)
   {
-  int ptr, size;
-  int p = Ustrlen(buffer);
-  int linekeylength;
+  size_t ptr, size, p = Ustrlen(buffer);
+  size_t linekeylength;
   BOOL this_is_comment;
   uschar *yield;
   uschar *s = buffer;
@@ -322,7 +321,7 @@ return FAIL;
 /* See local README for interface description */
 
 static int
-lsearch_find(void *handle, uschar *filename, const uschar *keystring, int length,
+lsearch_find(void *handle, uschar *filename, const uschar *keystring, size_t length,
   uschar **result, uschar **errmsg, uint *do_cache)
 {
 do_cache = do_cache;  /* Keep picky compilers happy */
@@ -339,7 +338,7 @@ return internal_lsearch_find(handle, filename, keystring, length, result,
 /* See local README for interface description */
 
 static int
-wildlsearch_find(void *handle, uschar *filename, const uschar *keystring, int length,
+wildlsearch_find(void *handle, uschar *filename, const uschar *keystring, size_t length,
   uschar **result, uschar **errmsg, uint *do_cache)
 {
 do_cache = do_cache;  /* Keep picky compilers happy */
@@ -356,7 +355,7 @@ return internal_lsearch_find(handle, filename, keystring, length, result,
 /* See local README for interface description */
 
 static int
-nwildlsearch_find(void *handle, uschar *filename, const uschar *keystring, int length,
+nwildlsearch_find(void *handle, uschar *filename, const uschar *keystring, size_t length,
   uschar **result, uschar **errmsg, uint *do_cache)
 {
 do_cache = do_cache;  /* Keep picky compilers happy */
@@ -374,7 +373,7 @@ return internal_lsearch_find(handle, filename, keystring, length, result,
 /* See local README for interface description */
 
 static int
-iplsearch_find(void *handle, uschar *filename, const uschar *keystring, int length,
+iplsearch_find(void *handle, uschar *filename, const uschar *keystring, size_t length,
   uschar **result, uschar **errmsg, uint *do_cache)
 {
 do_cache = do_cache;  /* Keep picky compilers happy */

--- a/src/src/lookups/mysql.c
+++ b/src/src/lookups/mysql.c
@@ -93,8 +93,8 @@ MYSQL_ROW mysql_row_data;
 MYSQL_FIELD *fields;
 
 int i;
-int ssize = 0;
-int offset = 0;
+size_t ssize = 0;
+size_t offset = 0;
 int yield = DEFER;
 unsigned int num_fields;
 uschar *result = NULL;

--- a/src/src/lookups/nisplus.c
+++ b/src/src/lookups/nisplus.c
@@ -46,8 +46,8 @@ nisplus_find(void *handle, uschar *filename, uschar *query, int length,
   uschar **result, uschar **errmsg, uint *do_cache)
 {
 int i;
-int ssize = 0;
-int offset = 0;
+size_t ssize = 0;
+size_t offset = 0;
 int error_error = FAIL;
 uschar *field_name = NULL;
 nis_result *nrt = NULL;
@@ -141,7 +141,7 @@ for (i = 0; i < eo->en_cols.en_cols_len; i++)
   {
   table_col *tc = ta->ta_cols.ta_cols_val + i;
   entry_col *ec = eo->en_cols.en_cols_val + i;
-  int len = ec->ec_value.ec_value_len;
+  size_t len = ec->ec_value.ec_value_len;
   uschar *value = US ec->ec_value.ec_value_val;
 
   /* The value may be NULL for a zero-length field. Turn this into an

--- a/src/src/lookups/oracle.c
+++ b/src/src/lookups/oracle.c
@@ -255,8 +255,8 @@ Ora_Define *def = NULL;
 void *hda = NULL;
 
 int i;
-int ssize = 0;
-int offset = 0;
+size_t ssize = 0;
+size_t offset = 0;
 int yield = DEFER;
 unsigned int num_fields = 0;
 uschar *result = NULL;
@@ -574,7 +574,7 @@ while ((c = *t++) != 0)
   if (strchr("\n\t\r\b\'\"\\", c) != NULL) count++;
 
 if (count == 0) return s;
-t = quoted = store_get((int)strlen(s) + count + 1);
+t = quoted = store_get(strlen(s) + count + 1);
 
 while ((c = *s++) != 0)
   {

--- a/src/src/lookups/pgsql.c
+++ b/src/src/lookups/pgsql.c
@@ -126,8 +126,8 @@ PGresult *pg_result = NULL;
 
 int i;
 uschar *result = NULL;
-int ssize = 0;
-int offset = 0;
+size_t ssize = 0;
+size_t offset = 0;
 int yield = DEFER;
 unsigned int num_fields, num_tuples;
 pgsql_connection *cn;

--- a/src/src/lookups/redis.c
+++ b/src/src/lookups/redis.c
@@ -80,8 +80,8 @@ redisReply *redis_reply = NULL;
 redisReply *entry = NULL;
 redisReply *tentry = NULL;
 redis_connection *cn;
-int ssize = 0;
-int offset = 0;
+size_t ssize = 0;
+size_t offset = 0;
 int yield = DEFER;
 int i, j;
 uschar *result = NULL;
@@ -210,7 +210,7 @@ if(sdata[1])
   uschar * argv[32];
   int i;
   const uschar * s = command;
-  int siz, ptr;
+  size_t siz, ptr;
   uschar c;
 
   while (isspace(*s)) s++;

--- a/src/src/lookups/sqlite.c
+++ b/src/src/lookups/sqlite.c
@@ -55,7 +55,7 @@ int i;
 /* For second and subsequent results, insert \n */
 
 if (res->string != NULL)
-  res->string = string_catn(res->string, &res->size, &res->len, US"\n", 1);
+  res->string = string_catn(res->string, (size_t *)(&res->size), (size_t *)(&res->len), US"\n", 1);
 
 if (argc > 1)
   {
@@ -64,7 +64,7 @@ if (argc > 1)
     {
     uschar *value = US((argv[i] != NULL)? argv[i]:"<NULL>");
     res->string = lf_quote(US azColName[i], value, Ustrlen(value), res->string,
-      &res->size, &res->len);
+      (size_t *)(&res->size), (size_t *)(&res->len));
     }
   }
 

--- a/src/src/malware.c
+++ b/src/src/malware.c
@@ -704,13 +704,14 @@ if (!malware_ok)
 	/* read and concatenate virus names into one string */
 	for (i = 0; i < drweb_vnum; i++)
 	  {
-	  int size = 0, off = 0, ovector[10*3];
+	  size_t size = 0, off = 0;
+	  int ovector[10*3];
 	  /* read the size of report */
 	  if (!recv_len(sock, &drweb_slen, sizeof(drweb_slen), tmo))
 	    return m_errlog_defer_3(scanent, CUS callout_address,
 			      US"cannot read report size", sock);
 	  drweb_slen = ntohl(drweb_slen);
-	  tmpbuf = store_get(drweb_slen);
+	  tmpbuf = store_get((size_t)drweb_slen);
 
 	  /* read report body */
 	  if (!recv_len(sock, tmpbuf, drweb_slen, tmo))

--- a/src/src/match.c
+++ b/src/src/match.c
@@ -143,8 +143,8 @@ if (pattern[0] == '^')
 if (pattern[0] == '*')
   {
   BOOL yield;
-  int slen = Ustrlen(s);
-  int patlen;    /* Sun compiler doesn't like non-constant initializer */
+  size_t slen = Ustrlen(s);
+  size_t patlen;    /* Sun compiler doesn't like non-constant initializer */
 
   patlen = Ustrlen(++pattern);
   if (patlen > slen) return FAIL;
@@ -1175,7 +1175,7 @@ if (pdomain != NULL)
 
   if (*pattern == '*')
     {
-    int cllen = pllen - 1;
+    size_t cllen = pllen - 1;
     if (sllen < cllen) return FAIL;
     if (cb->caseless)
       {

--- a/src/src/mime.c
+++ b/src/src/mime.c
@@ -456,7 +456,7 @@ mime_param_val(uschar ** sp)
 {
 uschar * s = *sp;
 uschar * val = NULL;
-int size = 0, ptr = 0;
+size_t size = 0, ptr = 0;
 
 /* debug_printf("   considering paramval '%s'\n", s); */
 
@@ -495,7 +495,7 @@ return s;
 static uschar *
 rfc2231_to_2047(const uschar * fname, const uschar * charset, int * len)
 {
-int size = 0, ptr = 0;
+size_t size = 0, ptr = 0;
 uschar * val = string_catn(NULL, &size, &ptr, US"=?", 2);
 uschar c;
 
@@ -644,7 +644,7 @@ while(1)
 
 	      if (!decoding_failed)
 		{
-		int size;
+		size_t size;
 		if (!mime_filename_charset)
 		  {
 		  uschar * s = q;

--- a/src/src/mime.h
+++ b/src/src/mime.h
@@ -25,14 +25,14 @@ struct mime_boundary_context
 
 typedef struct mime_header {
   uschar *  name;
-  int       namelen;
+  size_t       namelen;
   uschar ** value;
 } mime_header;
 
 
 typedef struct mime_parameter {
   uschar *  name;
-  int       namelen;
+  size_t       namelen;
   uschar ** value;
 } mime_parameter;
 

--- a/src/src/moan.c
+++ b/src/src/moan.c
@@ -614,7 +614,7 @@ const uschar *listptr = errors_copy;
 uschar *yield = NULL;
 uschar buffer[256];
 int sep = 0;
-int llen;
+size_t llen;
 
 if (errors_copy == NULL) return NULL;
 

--- a/src/src/parse.c
+++ b/src/src/parse.c
@@ -615,7 +615,7 @@ Returns:      points to the extracted address, or NULL on error
 #define FAILED(s) { *errorptr = s; goto PARSE_FAILED; }
 
 uschar *
-parse_extract_address(uschar *mailbox, uschar **errorptr, int *start, int *end,
+parse_extract_address(uschar *mailbox, uschar **errorptr, size_t *start, size_t *end,
   int *domain, BOOL allow_null)
 {
 uschar *yield = store_get(Ustrlen(mailbox) + 1);
@@ -863,8 +863,8 @@ Returns:       pointer to the original string, if no quoting needed, or
 */
 
 const uschar *
-parse_quote_2047(const uschar *string, int len, uschar *charset, uschar *buffer,
-  int buffer_size, BOOL fold)
+parse_quote_2047(const uschar *string, size_t len, uschar *charset, uschar *buffer,
+  size_t buffer_size, BOOL fold)
 {
 const uschar *s = string;
 uschar *p, *t;
@@ -982,7 +982,7 @@ Returns:       the fixed RFC822 phrase
 */
 
 const uschar *
-parse_fix_phrase(const uschar *phrase, int len, uschar *buffer, int buffer_size)
+parse_fix_phrase(const uschar *phrase, size_t len, uschar *buffer, size_t buffer_size)
 {
 int ch, i;
 BOOL quoted = FALSE;
@@ -1549,9 +1549,9 @@ for (;;)
 
   else
     {
-    int start, end, domain;
+    size_t start, end;
     uschar *recipient = NULL;
-    int save = s[len];
+    int domain, save = s[len];
     s[len] = 0;
 
     /* If it starts with \ and the rest of it parses as a valid mail address
@@ -2046,7 +2046,8 @@ return str;
 #if defined STAND_ALONE
 int main(void)
 {
-int start, end, domain;
+size_t start, end;
+int domain;
 uschar buffer[1024];
 uschar outbuff[1024];
 

--- a/src/src/pdkim/pdkim.c
+++ b/src/src/pdkim/pdkim.c
@@ -396,8 +396,8 @@ pdkim_parse_sig_header(pdkim_ctx *ctx, uschar * raw_hdr)
 {
 pdkim_signature *sig ;
 uschar *p, *q;
-uschar * cur_tag = NULL; int ts = 0, tl = 0;
-uschar * cur_val = NULL; int vs = 0, vl = 0;
+uschar * cur_tag = NULL; size_t ts = 0, tl = 0;
+uschar * cur_val = NULL; size_t vs = 0, vl = 0;
 BOOL past_hname = FALSE;
 BOOL in_b_val = FALSE;
 int where = PDKIM_HDR_LIMBO;
@@ -574,8 +574,8 @@ pdkim_parse_pubkey_record(pdkim_ctx *ctx, const uschar *raw_record)
 {
 pdkim_pubkey *pub;
 const uschar *p;
-uschar * cur_tag = NULL; int ts = 0, tl = 0;
-uschar * cur_val = NULL; int vs = 0, vl = 0;
+uschar * cur_tag = NULL; size_t ts = 0, tl = 0;
+uschar * cur_val = NULL; size_t vs = 0, vl = 0;
 int where = PDKIM_HDR_LIMBO;
 
 pub = store_get(sizeof(pdkim_pubkey));
@@ -1029,7 +1029,7 @@ return PDKIM_OK;
 
 /* Extend a grwong header with a continuation-linebreak */
 static uschar *
-pdkim_hdr_cont(uschar * str, int * size, int * ptr, int * col)
+pdkim_hdr_cont(uschar * str, size_t * size, size_t * ptr, int * col)
 {
 *col = 1;
 return string_catn(str, size, ptr, US"\r\n\t", 3);
@@ -1062,7 +1062,7 @@ return string_catn(str, size, ptr, US"\r\n\t", 3);
  */
 
 static uschar *
-pdkim_headcat(int * col, uschar * str, int * size, int * ptr,
+pdkim_headcat(int * col, uschar * str, size_t * size, size_t * ptr,
   const uschar * pad, const uschar * intro, const uschar * payload)
 {
 size_t l;
@@ -1164,8 +1164,8 @@ pdkim_create_header(pdkim_signature *sig, BOOL final)
 uschar * base64_bh;
 uschar * base64_b;
 int col = 0;
-uschar * hdr;       int hdr_size = 0, hdr_len = 0;
-uschar * canon_all; int can_size = 0, can_len = 0;
+uschar * hdr;       size_t hdr_size = 0, hdr_len = 0;
+uschar * canon_all; size_t can_size = 0, can_len = 0;
 
 canon_all = string_cat (NULL, &can_size, &can_len,
 		      pdkim_canons[sig->canon_headers]);
@@ -1266,7 +1266,7 @@ pdkim_feed_finish(pdkim_ctx *ctx, pdkim_signature **return_signatures)
 {
 pdkim_signature *sig = ctx->sig;
 uschar * headernames = NULL;             /* Collected signed header names */
-int hs = 0, hl = 0;
+size_t hs = 0, hl = 0;
 
 /* Check if we must still flush a (partial) header. If that is the
    case, the message has no body, and we must compute a body hash
@@ -1291,7 +1291,7 @@ while (sig)
   uschar * sig_hdr;
   blob hhash;
   blob hdata;
-  int hdata_alloc = 0;
+  size_t hdata_alloc = 0;
 
   hdata.data = NULL;
   hdata.len = 0;

--- a/src/src/pdkim/pdkim.h
+++ b/src/src/pdkim/pdkim.h
@@ -258,10 +258,10 @@ typedef struct pdkim_ctx {
 
   /* Coder's little helpers */
   uschar    *cur_header;
-  int        cur_header_size;
-  int        cur_header_len;
+  size_t        cur_header_size;
+  size_t        cur_header_len;
   char      *linebuf;
-  int        linebuf_offset;
+  size_t        linebuf_offset;
   BOOL       seen_lf;
   BOOL       seen_eod;
   BOOL       past_headers;

--- a/src/src/pdkim/rsa.c
+++ b/src/src/pdkim/rsa.c
@@ -29,9 +29,9 @@ exim_rsa_init(void)
 
 /* accumulate data (gnutls-only).  String to be appended must be nul-terminated. */
 blob *
-exim_rsa_data_append(blob * b, int * alloc, uschar * s)
+exim_rsa_data_append(blob * b, size_t * alloc, uschar * s)
 {
-int len = b->len;
+size_t len= b-> len;
 b->data = string_append(b->data, alloc, &len, 1, s);
 b->len = len;
 return b;
@@ -259,7 +259,7 @@ return;
 String to be appended must be nul-terminated. */
 
 blob *
-exim_rsa_data_append(blob * b, int * alloc, uschar * s)
+exim_rsa_data_append(blob * b, size_t * alloc, uschar * s)
 {
 return b;	/*dummy*/
 }
@@ -556,7 +556,7 @@ exim_rsa_init(void)
 
 /* accumulate data (gnutls-only) */
 blob *
-exim_rsa_data_append(blob * b, int * alloc, uschar * s)
+exim_rsa_data_append(blob * b, size_t * alloc, uschar * s)
 {
 return b;	/*dummy*/
 }
@@ -604,7 +604,7 @@ Return: NULL for success, or an error string */
 const uschar *
 exim_rsa_sign(es_ctx * sign_ctx, BOOL is_sha1, blob * data, blob * sig)
 {
-uint len;
+size_t len;
 const uschar * ret = NULL;
 
 /* Allocate mem for signature */

--- a/src/src/pdkim/rsa.h
+++ b/src/src/pdkim/rsa.h
@@ -70,7 +70,7 @@ typedef struct {
 
 
 extern void exim_rsa_init(void);
-extern blob * exim_rsa_data_append(blob *, int *, uschar *);
+extern blob * exim_rsa_data_append(blob *, size_t *, uschar *);
 
 extern const uschar * exim_rsa_signing_init(uschar *, es_ctx *);
 extern const uschar * exim_rsa_sign(es_ctx *, BOOL, blob *, blob *);

--- a/src/src/queue.c
+++ b/src/src/queue.c
@@ -824,7 +824,7 @@ reset_point = store_get(0);
 for (; f != NULL; f = f->next)
   {
   int rc, save_errno;
-  int size = 0;
+  size_t size = 0;
   BOOL env_read;
 
   store_reset(reset_point);
@@ -1252,7 +1252,8 @@ switch(action)
 
   for (; recipients_arg < argc; recipients_arg++)
     {
-    int start, end, domain;
+    size_t start, end;
+    int domain;
     uschar *errmess;
     uschar *recipient =
       parse_extract_address(argv[recipients_arg], &errmess, &start, &end,

--- a/src/src/rda.c
+++ b/src/src/rda.c
@@ -471,7 +471,7 @@ Returns:     FALSE if data missing
 static BOOL
 rda_read_string(int fd, uschar **sp)
 {
-int len;
+size_t len;
 
 if (read(fd, &len, sizeof(int)) != sizeof(int)) return FALSE;
 if (len == 0) *sp = NULL; else

--- a/src/src/readconf.c
+++ b/src/src/readconf.c
@@ -2838,7 +2838,7 @@ Returns:      nothing
 */
 
 static void
-read_named_list(tree_node **anchorp, int *numberp, int max, uschar *s,
+read_named_list(tree_node **anchorp, int *numberp, size_t max, uschar *s,
   uschar *tname)
 {
 BOOL forcecache = FALSE;
@@ -2856,8 +2856,8 @@ if (!isspace(*s))
   log_write(0, LOG_PANIC_DIE|LOG_CONFIG_IN, "unrecognized configuration line");
 
 if (*numberp >= max)
- log_write(0, LOG_PANIC_DIE|LOG_CONFIG_IN, "too many named %ss (max is %d)\n",
-   tname, max);
+ log_write(0, LOG_PANIC_DIE|LOG_CONFIG_IN, "too many named %ss (max is %u)\n",
+   tname, (unsigned int)max);
 
 while (isspace(*s)) s++;
 ss = s;
@@ -3416,7 +3416,8 @@ and ensure it contains a domain. */
 if (errors_reply_to != NULL)
   {
   uschar *errmess;
-  int start, end, domain;
+  size_t start, end;
+  int domain;
   uschar *recipient = parse_extract_address(errors_reply_to, &errmess,
     &start, &end, &domain, FALSE);
 
@@ -3543,7 +3544,7 @@ for (dd = drivers_available; dd->driver_name[0] != 0;
   if (Ustrcmp(d->driver_name, dd->driver_name) == 0)
     {
     int i;
-    int len = dd->options_len;
+    size_t len = dd->options_len;
     d->info = dd;
     d->options_block = store_get(len);
     memcpy(d->options_block, dd->options_block, len);
@@ -3660,7 +3661,7 @@ while ((buffer = get_config_line()) != NULL)
     /* Set up a new driver instance data block on the chain, with
     its default values installed. */
 
-    d = store_get(instance_size);
+    d = store_get((size_t)instance_size);
     memcpy(d, instance_default, instance_size);
     *p = d;
     p = &d->next;
@@ -3790,7 +3791,7 @@ uschar *
 readconf_retry_error(const uschar *pp, const uschar *p,
   int *basic_errno, int *more_errno)
 {
-int len;
+size_t len;
 const uschar *q = pp;
 while (q < p && *q != '_') q++;
 len = q - pp;
@@ -3819,7 +3820,7 @@ else if (len == 7 && strncmpic(pp, US"timeout", len) == 0)
   if (q != p)
     {
     int i;
-    int xlen = p - q - 1;
+    size_t xlen = p - q - 1;
     const uschar *x = q + 1;
 
     static uschar *extras[] =

--- a/src/src/receive.c
+++ b/src/src/receive.c
@@ -1123,7 +1123,7 @@ Returns:      the extended string
 */
 
 static uschar *
-add_host_info_for_log(uschar *s, int *sizeptr, int *ptrptr)
+add_host_info_for_log(uschar *s, size_t *sizeptr, size_t *ptrptr)
 {
 if (sender_fullhost != NULL)
   {
@@ -1444,14 +1444,14 @@ not. */
 BOOL
 receive_msg(BOOL extract_recip)
 {
-int  i;
+int  i, domain;
 int  rc = FAIL;
 int  msg_size = 0;
 int  process_info_len = Ustrlen(process_info);
 int  error_rc = (error_handling == ERRORS_SENDER)?
        errors_sender_rc : EXIT_FAILURE;
-int  header_size = 256;
-int  start, end, domain, size, sptr;
+size_t  header_size = 256;
+size_t  start, end, size, sptr;
 int  id_resolution;
 int  had_zero = 0;
 int  prevlines_length = 0;
@@ -1897,7 +1897,8 @@ for (;;)
         }
       else
         {
-        int start, end, domain;
+        size_t start, end;
+        int domain;
         uschar *errmess;
         uschar *newsender = parse_extract_address(uucp_sender, &errmess,
           &start, &end, &domain, TRUE);
@@ -2111,7 +2112,7 @@ for (h = header_list->next; h != NULL; h = h->next)
       from_header = h;
       if (!smtp_input)
         {
-        int len;
+        size_t len;
         uschar *s = Ustrchr(h->text, ':') + 1;
         while (isspace(*s)) s++;
         len = h->slen - (s - h->text) - 1;
@@ -2295,7 +2296,8 @@ if (extract_recip)
         {
         uschar *ss = parse_find_address_end(s, FALSE);
         uschar *recipient, *errmess, *p, *pp;
-        int start, end, domain;
+        size_t start, end;
+        int domain;
 
         /* Check on maximum */
 
@@ -2341,7 +2343,7 @@ if (extract_recip)
 
         if (recipient == NULL && Ustrcmp(errmess, "empty address") != 0)
           {
-          int len = Ustrlen(s);
+          size_t len = Ustrlen(s);
           error_block *b = store_get(sizeof(error_block));
           while (len > 0 && isspace(s[len-1])) len--;
           b->next = NULL;
@@ -2666,7 +2668,8 @@ if (from_header != NULL &&
      ))
   {
   BOOL make_sender = TRUE;
-  int start, end, domain;
+  size_t start, end;
+  int domain;
   uschar *errmess;
   uschar *from_address =
     parse_extract_address(Ustrchr(from_header->text, ':') + 1, &errmess,
@@ -3200,8 +3203,8 @@ else
           const uschar *ptr = dkim_verify_signers_expanded;
           uschar *item = NULL;
           uschar *seen_items = NULL;
-          int     seen_items_size = 0;
-          int     seen_items_offset = 0;
+          size_t     seen_items_size = 0;
+          size_t     seen_items_offset = 0;
           uschar itembuf[256];
           /* Default to OK when no items are present */
           rc = OK;
@@ -3516,7 +3519,7 @@ os_non_restarting_signal(SIGBUS, SIG_DFL);
 
 if (local_scan_data != NULL)
   {
-  int len = Ustrlen(local_scan_data);
+  size_t len = Ustrlen(local_scan_data);
   if (len > LOCAL_SCAN_MAX_RETURN) len = LOCAL_SCAN_MAX_RETURN;
   local_scan_data = string_copyn(local_scan_data, len);
   }
@@ -3570,8 +3573,8 @@ else
   uschar *istemp = US"";
   uschar *s = NULL;
   uschar *smtp_code;
-  int size = 0;
-  int sptr = 0;
+  size_t size = 0;
+  size_t sptr = 0;
 
   errmsg = local_scan_data;
 

--- a/src/src/rewrite.c
+++ b/src/src/rewrite.c
@@ -116,8 +116,8 @@ for (rule = rewrite_rules;
      rule != NULL && !done;
      rule_number++, rule = rule->next)
   {
-  int start, end, pdomain;
-  int count = 0;
+  size_t start, end;
+  int pdomain, count = 0;
   uschar *save_localpart;
   const uschar *save_domain;
   uschar *error, *new, *newparsed;
@@ -479,7 +479,8 @@ while (*s != 0)
   void *loop_reset_point = store_get(0);
   BOOL changed = FALSE;
   int terminator = *ss;
-  int start, end, domain;
+  size_t start, end;
+  int domain;
 
   /* Temporarily terminate the string at this point, and extract the
   operative address within. Then put back the terminator and prepare for
@@ -660,7 +661,7 @@ while (*s != 0)
     newh = store_get(sizeof(header_line));
     newh->type = type;
     newh->slen = slen;
-    newh->text = string_copyn(newtstart, slen);
+    newh->text = string_copyn(newtstart, (size_t)slen);
     store_free(newtstart);
 
     /* Set up for scanning the rest of the header */
@@ -768,7 +769,8 @@ Returns:  nothing
 void rewrite_test(uschar *s)
 {
 uschar *recipient, *error;
-int i, start, end, domain;
+size_t start, end;
+int i, domain;
 BOOL done_smtp = FALSE;
 
 if (rewrite_existflags == 0)
@@ -823,7 +825,7 @@ for (i = 0; i < 8; i++)
     printf("<>\n");
   else if (whole || (flag & rewrite_all_headers) == 0)
     printf("%s\n", CS new);
-  else printf("%.*s%s%s\n", start, s, new, s+end);
+  else printf("%.*s%s%s\n", (int)start, s, new, s+end);
   }
 }
 

--- a/src/src/rfc2047.c
+++ b/src/src/rfc2047.c
@@ -186,10 +186,10 @@ Returns:         the decoded, converted string, or NULL on error; if there are
 
 uschar *
 rfc2047_decode2(uschar *string, BOOL lencheck, uschar *target, int zeroval,
-  int *lenptr, int *sizeptr, uschar **error)
+  size_t *lenptr, size_t *sizeptr, uschar **error)
 {
-int ptr = 0;
-int size = Ustrlen(string);
+size_t ptr = 0;
+size_t size = Ustrlen(string);
 size_t dlen;
 uschar *dptr, *yield;
 uschar *mimeword, *q1, *q2, *endword;
@@ -341,7 +341,7 @@ argument. */
 
 uschar *
 rfc2047_decode(uschar *string, BOOL lencheck, uschar *target, int zeroval,
-  int *lenptr, uschar **error)
+  size_t *lenptr, uschar **error)
 {
 return rfc2047_decode2(string, lencheck, target, zeroval, lenptr, NULL, error);
 }

--- a/src/src/route.c
+++ b/src/src/route.c
@@ -328,7 +328,7 @@ uschar prebuf[64];
 
 while ((prefix = string_nextinlist(&listptr, &sep, prebuf, sizeof(prebuf))))
   {
-  int plen = Ustrlen(prefix);
+  size_t plen = Ustrlen(prefix);
   if (prefix[0] == '*')
     {
     const uschar *p;
@@ -372,7 +372,7 @@ uschar sufbuf[64];
 
 while ((suffix = string_nextinlist(&listptr, &sep, sufbuf, sizeof(sufbuf))))
   {
-  int slen = Ustrlen(suffix);
+  size_t slen = Ustrlen(suffix);
   if (suffix[slen-1] == '*')
     {
     const uschar *p, *pend;
@@ -1529,7 +1529,7 @@ for (r = addr->start_router ? addr->start_router : routers; r; r = nextr)
 
   if (r->prefix)
     {
-    int plen = route_check_prefix(addr->local_part, r->prefix);
+    size_t plen = route_check_prefix(addr->local_part, r->prefix);
     if (plen > 0)
       {
       addr->prefix = string_copyn(addr->local_part, plen);
@@ -1551,7 +1551,7 @@ for (r = addr->start_router ? addr->start_router : routers; r; r = nextr)
     int slen = route_check_suffix(addr->local_part, r->suffix);
     if (slen > 0)
       {
-      int lplen = Ustrlen(addr->local_part) - slen;
+      size_t lplen = Ustrlen(addr->local_part) - slen;
       addr->suffix = addr->local_part + lplen;
       addr->local_part = string_copyn(addr->local_part, lplen);
       DEBUG(D_route) debug_printf("stripped suffix %s\n", addr->suffix);

--- a/src/src/sieve.c
+++ b/src/src/sieve.c
@@ -98,7 +98,7 @@ enum RelOp { LT, LE, EQ, GE, GT, NE };
 struct String
   {
   uschar *character;
-  int length;
+  size_t length;
   };
 
 struct Notification
@@ -320,7 +320,8 @@ Returns
 
 int check_mail_address(struct Sieve *filter, const struct String *address)
 {
-int start, end, domain;
+size_t start, end;
+int domain;
 uschar *error,*ss;
 
 if (address->length>0)
@@ -414,7 +415,7 @@ static int parse_mailto_uri(struct Sieve *filter, const uschar *uri, string_item
 {
 const uschar *start;
 struct String to,hname,hvalue;
-int capacity;
+size_t capacity;
 string_item *new;
 
 if (Ustrncmp(uri,"mailto:",7))
@@ -841,8 +842,8 @@ if ((filter_test != FTEST_NONE && debug_selector != 0) ||
     case COMP_ASCII_NUMERIC: debug_printf("i;ascii-numeric"); break;
     }
   debug_printf("\"):\n");
-  debug_printf("  Search = %s (%d chars)\n", needle->character,needle->length);
-  debug_printf("  Inside = %s (%d chars)\n", haystack->character,haystack->length);
+  debug_printf("  Search = %s (%u chars)\n", needle->character,(unsigned int)needle->length);
+  debug_printf("  Inside = %s (%u chars)\n", haystack->character,(unsigned int)haystack->length);
   }
 switch (mt)
   {
@@ -994,7 +995,7 @@ Returns:      quoted string
 static const uschar *quote(const struct String *header)
 {
 uschar *quoted=NULL;
-int size=0,ptr=0;
+size_t size=0,ptr=0;
 size_t l;
 const uschar *h;
 
@@ -1472,7 +1473,7 @@ Returns:      1                success
 
 static int parse_string(struct Sieve *filter, struct String *data)
 {
-int dataCapacity=0;
+size_t dataCapacity=0;
 
 data->length=0;
 data->character=(uschar*)0;
@@ -1483,7 +1484,7 @@ if (*filter->pc=='"') /* quoted string */
     {
     if (*filter->pc=='"') /* end of string */
       {
-      int foo=data->length;
+      size_t foo=data->length;
 
       ++filter->pc;
       /* that way, there will be at least one character allocated */
@@ -1566,7 +1567,7 @@ else if (Ustrncmp(filter->pc,CUS "text:",5)==0) /* multiline string */
       if (*filter->pc=='.' && *(filter->pc+1)=='\n') /* end of string */
 #endif
         {
-        int foo=data->length;
+        size_t foo=data->length;
 
         /* that way, there will be at least one character allocated */
         data->character=string_catn(data->character,&dataCapacity,&foo,CUS "",1);
@@ -2126,8 +2127,8 @@ if (parse_identifier(filter,CUS "address"))
       while (*header_value && !*cond)
         {
         uschar *error;
-        int start, end, domain;
-        int saveend;
+        size_t start, end;
+        int saveend, domain;
         uschar *part=NULL;
 
         end_addr = parse_find_address_end(header_value, FALSE);
@@ -3105,7 +3106,7 @@ while (*filter->pc)
                 }
               /* Allocation is larger than neccessary, but enough even for split MIME words */
               buffer_capacity=32+4*message.length;
-              buffer=store_get(buffer_capacity);
+              buffer=store_get((size_t)buffer_capacity);
               if (message.length!=-1) fprintf(f,"Subject: %s\n",parse_quote_2047(message.character, message.length, US"utf-8", buffer, buffer_capacity, TRUE));
               fprintf(f,"\n");
               if (body.length>0) fprintf(f,"%s\n",body.character);
@@ -3272,7 +3273,7 @@ while (*filter->pc)
     if (exec)
       {
       address_item *addr;
-      int capacity,start;
+      size_t capacity,start;
       uschar *buffer;
       int buffer_capacity;
       struct String key;
@@ -3357,7 +3358,7 @@ while (*filter->pc)
             addr->reply->from = from.character;
           /* Allocation is larger than neccessary, but enough even for split MIME words */
           buffer_capacity=32+4*subject.length;
-          buffer=store_get(buffer_capacity);
+          buffer=store_get((size_t)buffer_capacity);
 	  /* deconst cast safe as we pass in a non-const item */
           addr->reply->subject = US parse_quote_2047(subject.character, subject.length, US"utf-8", buffer, buffer_capacity, TRUE);
           addr->reply->oncelog=once;

--- a/src/src/smtp_in.c
+++ b/src/src/smtp_in.c
@@ -54,7 +54,7 @@ we need room to handle large base64-encoded AUTHs for GSSAPI.
 
 typedef struct {
   const char *name;
-  int len;
+  size_t len;
   short int cmd;
   short int has_arg;
   short int is_mail_cmd;
@@ -1254,10 +1254,10 @@ Arguments:
 Returns:	Allocated string or NULL
 */
 static uschar *
-s_tlslog(uschar * s, int * sizep, int * ptrp)
+s_tlslog(uschar * s, size_t * sizep, size_t * ptrp)
 {
-  int size = sizep ? *sizep : 0;
-  int ptr = ptrp ? *ptrp : 0;
+  size_t size = sizep ? *sizep : 0;
+  size_t ptr = ptrp ? *ptrp : 0;
 
   if (LOGGING(tls_cipher) && tls_in.cipher != NULL)
     s = string_append(s, &size, &ptr, 2, US" X=", tls_in.cipher);
@@ -1296,14 +1296,14 @@ Returns:     nothing
 void
 smtp_log_no_mail(void)
 {
-int size, ptr, i;
+size_t size=0, ptr=0;
+int i;
 uschar *s, *sep;
 
 if (smtp_mailcmd_count > 0 || !LOGGING(smtp_no_mail))
   return;
 
 s = NULL;
-size = ptr = 0;
 
 if (sender_host_authenticated != NULL)
   {
@@ -1628,7 +1628,8 @@ while (done <= 0)
   {
   uschar *errmess;
   uschar *recipient = NULL;
-  int start, end, sender_domain, recipient_domain;
+  size_t start, end;
+  int sender_domain, recipient_domain;
 
   switch(smtp_read_command(FALSE))
     {
@@ -1842,8 +1843,8 @@ Returns:       FALSE if the session can not continue; something has
 BOOL
 smtp_start_session(void)
 {
-int size = 256;
-int ptr, esclen;
+size_t ptr, size = 256;
+int esclen;
 uschar *user_msg, *log_msg;
 uschar *code, *esc;
 uschar *p, *s, *ss;
@@ -1999,15 +2000,15 @@ if (!sender_host_unknown)
     {
     #if OPTSTYLE == 1
     EXIM_SOCKLEN_T optlen = sizeof(struct ip_options) + MAX_IPOPTLEN;
-    struct ip_options *ipopt = store_get(optlen);
+    struct ip_options *ipopt = store_get((size_t)optlen);
     #elif OPTSTYLE == 2
     struct ip_opts ipoptblock;
     struct ip_opts *ipopt = &ipoptblock;
-    EXIM_SOCKLEN_T optlen = sizeof(ipoptblock);
+    EXIM_SOCKLEN_T optlen = sizeof((size_t)ipoptblock);
     #else
     struct ipoption ipoptblock;
     struct ipoption *ipopt = &ipoptblock;
-    EXIM_SOCKLEN_T optlen = sizeof(ipoptblock);
+    EXIM_SOCKLEN_T optlen = sizeof((size_t)ipoptblock);
     #endif
 
     /* Occasional genuine failures of getsockopt() have been seen - for
@@ -3292,8 +3293,8 @@ while (done <= 0)
   void (*oldsignal)(int);
   pid_t pid;
   int start, end, sender_domain, recipient_domain;
-  int ptr, size, rc;
-  int c;
+  size_t ptr, size;
+  int c, rc;
   auth_instance *au;
   uschar *orcpt = NULL;
   int flags;
@@ -4096,7 +4097,7 @@ while (done <= 0)
       ? rewrite_one(smtp_cmd_data, rewrite_smtp, NULL, FALSE, US"",
 		    global_rewrite_rules)
       : smtp_cmd_data;
-
+      size_t start, end;
     /* rfc821_domains = TRUE; << no longer needed */
     raw_sender =
       parse_extract_address(raw_sender, &errmess, &start, &end, &sender_domain,

--- a/src/src/srs.c
+++ b/src/src/srs.c
@@ -188,7 +188,7 @@ srs_result eximsrs_db_insert(srs_t *srs, char *data, uint data_len, char *result
   if(srs_db_forward == NULL)
     return SRS_RESULT_DBERROR;
 
-  srs_db_address = string_copyn(data, data_len);
+  srs_db_address = string_copyn(data, (size_t)data_len);
   if(srs_generate_unique_id(srs, srs_db_address, buf, 64) & SRS_RESULT_FAIL)
     return SRS_RESULT_DBERROR;
 
@@ -213,7 +213,7 @@ srs_result eximsrs_db_lookup(srs_t *srs, char *data, uint data_len, char *result
   if(srs_db_reverse == NULL)
     return SRS_RESULT_DBERROR;
 
-  srs_db_key = string_copyn(data, data_len);
+  srs_db_key = string_copyn(data, (size_t)data_len);
   if((res = expand_string(srs_db_reverse)) == NULL)
     return SRS_RESULT_DBERROR;
 

--- a/src/src/store.c
+++ b/src/src/store.c
@@ -126,7 +126,7 @@ Returns:      pointer to store (panic on malloc failure)
 */
 
 void *
-store_get_3(int size, const char *filename, int linenumber)
+store_get_3(size_t size, const char *filename, int linenumber)
 {
 /* Round up the size to a multiple of the alignment. Although this looks a
 messy statement, because "alignment" is a constant expression, the compiler can
@@ -195,10 +195,10 @@ linenumber = linenumber;
 DEBUG(D_memory)
   {
   if (running_in_test_harness)
-    debug_printf("---%d Get %5d\n", store_pool, size);
+    debug_printf("---%d Get %5u\n", store_pool, (unsigned int)size);
   else
-    debug_printf("---%d Get %6p %5d %-14s %4d\n", store_pool,
-      store_last_get[store_pool], size, filename, linenumber);
+    debug_printf("---%d Get %6p %5u %-14s %4d\n", store_pool,
+      store_last_get[store_pool], (unsigned int)size, filename, linenumber);
   }
 #endif  /* COMPILE_UTILITY */
 
@@ -229,7 +229,7 @@ Returns:      pointer to store (panic on malloc failure)
 */
 
 void *
-store_get_perm_3(int size, const char *filename, int linenumber)
+store_get_perm_3(size_t size, const char *filename, int linenumber)
 {
 void *yield;
 int old_pool = store_pool;
@@ -492,7 +492,7 @@ Returns:      pointer to gotten store (panic on failure)
 */
 
 void *
-store_malloc_3(int size, const char *filename, int linenumber)
+store_malloc_3(size_t size, const char *filename, int linenumber)
 {
 void *yield;
 
@@ -500,7 +500,7 @@ if (size < 16) size = 16;
 yield = malloc((size_t)size);
 
 if (yield == NULL)
-  log_write(0, LOG_MAIN|LOG_PANIC_DIE, "failed to malloc %d bytes of memory: "
+  log_write(0, LOG_MAIN|LOG_PANIC_DIE, "failed to malloc %zd bytes of memory: "
     "called from line %d of %s", size, linenumber, filename);
 
 nonpool_malloc += size;
@@ -519,12 +519,12 @@ is not filled with zeros so as to catch problems. */
 if (running_in_test_harness)
   {
   memset(yield, 0xF0, (size_t)size);
-  DEBUG(D_memory) debug_printf("--Malloc %5d %d %d\n", size, pool_malloc,
+  DEBUG(D_memory) debug_printf("--Malloc %5zd %d %d\n", size, pool_malloc,
     nonpool_malloc);
   }
 else
   {
-  DEBUG(D_memory) debug_printf("--Malloc %6p %5d %-14s %4d %d %d\n", yield,
+  DEBUG(D_memory) debug_printf("--Malloc %6p %5zd %-14s %4d %d %d\n", yield,
     size, filename, linenumber, pool_malloc, nonpool_malloc);
   }
 #endif  /* COMPILE_UTILITY */

--- a/src/src/store.h
+++ b/src/src/store.h
@@ -42,9 +42,9 @@ tracing information for debugging. */
 
 extern BOOL    store_extend_3(void *, int, int, const char *, int);  /* The */
 extern void    store_free_3(void *, const char *, int);     /* value of the */
-extern void   *store_get_3(int, const char *, int);         /* 2nd arg is   */
-extern void   *store_get_perm_3(int, const char *, int);    /* __FILE__ in  */
-extern void   *store_malloc_3(int, const char *, int);      /* every call,  */
+extern void   *store_get_3(size_t, const char *, int);         /* 2nd arg is   */
+extern void   *store_get_perm_3(size_t, const char *, int);    /* __FILE__ in  */
+extern void   *store_malloc_3(size_t, const char *, int);      /* every call,  */
 extern void    store_release_3(void *, const char *, int);  /* so give its  */
 extern void    store_reset_3(void *, const char *, int);    /* correct type */
 

--- a/src/src/string.c
+++ b/src/src/string.c
@@ -163,18 +163,18 @@ Returns:      pointer to the buffer
 */
 
 uschar *
-string_format_size(int size, uschar *buffer)
+string_format_size(size_t size, uschar *buffer)
 {
 if (size == 0) Ustrcpy(buffer, "     ");
-else if (size < 1024) sprintf(CS buffer, "%5d", size);
+else if (size < 1024) sprintf(CS buffer, "%5zd", size);
 else if (size < 10*1024)
   sprintf(CS buffer, "%4.1fK", (double)size / 1024.0);
 else if (size < 1024*1024)
-  sprintf(CS buffer, "%4dK", (size + 512)/1024);
+  sprintf(CS buffer, "%4zdK", (size + 512)/1024);
 else if (size < 10*1024*1024)
   sprintf(CS buffer, "%4.1fM", (double)size / (1024.0 * 1024.0));
 else
-  sprintf(CS buffer, "%4dM", (size + 512 * 1024)/(1024*1024));
+  sprintf(CS buffer, "%4zdM", (size + 512 * 1024)/(1024*1024));
 return buffer;
 }
 
@@ -354,7 +354,7 @@ uschar *
 string_unprinting(uschar *s)
 {
 uschar *p, *q, *r, *ss;
-int len, off;
+size_t len, off;
 
 p = Ustrchr(s, '\\');
 if (!p) return s;
@@ -418,7 +418,7 @@ Returns:  copy of string in new store
 uschar *
 string_copy(const uschar *s)
 {
-int len = Ustrlen(s) + 1;
+size_t len = Ustrlen(s) + 1;
 uschar *ss = store_get(len);
 memcpy(ss, s, len);
 return ss;
@@ -439,7 +439,7 @@ Returns:  copy of string in new store
 uschar *
 string_copy_malloc(const uschar *s)
 {
-int len = Ustrlen(s) + 1;
+size_t len = Ustrlen(s) + 1;
 uschar *ss = store_malloc(len);
 memcpy(ss, s, len);
 return ss;
@@ -483,7 +483,7 @@ Returns:    copy of string in new store
 */
 
 uschar *
-string_copyn(const uschar *s, int n)
+string_copyn(const uschar *s, size_t n)
 {
 uschar *ss = store_get(n + 1);
 Ustrncpy(ss, s, n);
@@ -507,7 +507,7 @@ Returns:    copy of string in new store, with letters lowercased
 */
 
 uschar *
-string_copynlc(uschar *s, int n)
+string_copynlc(uschar *s, size_t n)
 {
 uschar *ss = store_get(n + 1);
 uschar *p = ss;
@@ -740,7 +740,7 @@ Returns:    < 0, = 0, or > 0, according to the comparison
 */
 
 int
-strncmpic(const uschar *s, const uschar *t, int n)
+strncmpic(const uschar *s, const uschar *t, size_t n)
 {
 while (n--)
   {
@@ -927,8 +927,8 @@ if (buffer != NULL)
 
 else
   {
-  int size = 0;
-  int ptr = 0;
+  size_t size = 0;
+  size_t ptr = 0;
   const uschar *ss;
 
   /* We know that *s != 0 at this point. However, it might be pointing to a
@@ -990,7 +990,7 @@ uschar *
 string_append_listele(uschar * list, uschar sep, const uschar * ele)
 {
 uschar * new = NULL;
-int sz = 0, off = 0;
+size_t sz = 0, off = 0;
 uschar * sp;
 
 if (list)
@@ -1012,7 +1012,7 @@ return new;
 
 
 static const uschar *
-Ustrnchr(const uschar * s, int c, unsigned * len)
+Ustrnchr(const uschar * s, int c, size_t * len)
 {
 unsigned siz = *len;
 while (siz)
@@ -1031,10 +1031,10 @@ return NULL;
 
 uschar *
 string_append_listele_n(uschar * list, uschar sep, const uschar * ele,
-  unsigned len)
+  size_t len)
 {
 uschar * new = NULL;
-int sz = 0, off = 0;
+size_t sz = 0, off = 0;
 const uschar * sp;
 
 if (list)
@@ -1091,13 +1091,13 @@ Returns:   pointer to the start of the string, changed if copied for expansion.
 /* coverity[+alloc] */
 
 uschar *
-string_catn(uschar *string, int *size, int *ptr, const uschar *s, int count)
+string_catn(uschar *string, size_t *size, size_t *ptr, const uschar *s, size_t count)
 {
 int p = *ptr;
 
 if (p + count >= *size)
   {
-  int oldsize = *size;
+  size_t oldsize = *size;
 
   /* Mostly, string_cat() is used to build small strings of a few hundred
   characters at most. There are times, however, when the strings are very much
@@ -1149,7 +1149,7 @@ return string;
 
 
 uschar *
-string_cat(uschar *string, int *size, int *ptr, const uschar *s)
+string_cat(uschar *string, size_t *size, size_t *ptr, const uschar *s)
 {
 return string_catn(string, size, ptr, s, Ustrlen(s));
 }
@@ -1181,7 +1181,7 @@ Returns:   pointer to the start of the string, changed if copied for expansion.
 */
 
 uschar *
-string_append(uschar *string, int *size, int *ptr, int count, ...)
+string_append(uschar *string, size_t *size, size_t *ptr, int count, ...)
 {
 va_list ap;
 int i;
@@ -1227,7 +1227,7 @@ Returns:       TRUE if the result fitted in the buffer
 */
 
 BOOL
-string_format(uschar *buffer, int buflen, const char *format, ...)
+string_format(uschar *buffer, size_t buflen, const char *format, ...)
 {
 BOOL yield;
 va_list ap;
@@ -1239,7 +1239,7 @@ return yield;
 
 
 BOOL
-string_vformat(uschar *buffer, int buflen, const char *format, va_list ap)
+string_vformat(uschar *buffer, size_t buflen, const char *format, va_list ap)
 {
 /* We assume numbered ascending order, C does not guarantee that */
 enum { L_NORMAL=1, L_SHORT=2, L_LONG=3, L_LONGLONG=4, L_LONGDOUBLE=5, L_SIZE=6 };
@@ -1258,9 +1258,9 @@ string_datestamp_type = 0;     /* Datestamp not inserted */
 
 while (*fp != 0)
   {
-  int length = L_NORMAL;
+  size_t length = L_NORMAL;
   int *nptr;
-  int slen;
+  size_t slen;
   const char *null = "NULL";   /* ) These variables */
   const char *item_start, *s;  /* ) are deliberately */
   char newformat[16];          /* ) not unsigned */
@@ -1561,8 +1561,8 @@ Returns:      the new value of the buffer pointer
 */
 
 static uschar *
-string_get_localpart(address_item *addr, uschar *yield, int *sizeptr,
-  int *ptrptr)
+string_get_localpart(address_item *addr, uschar *yield, size_t *sizeptr,
+  size_t *ptrptr)
 {
 uschar * s;
 
@@ -1618,8 +1618,8 @@ Returns:        a string in dynamic store
 uschar *
 string_log_address(address_item *addr, BOOL all_parents, BOOL success)
 {
-int size = 64;
-int ptr = 0;
+size_t size = 64;
+size_t ptr = 0;
 BOOL add_topaddr = TRUE;
 uschar *yield = store_get(size);
 address_item *topaddr;

--- a/src/src/structs.h
+++ b/src/src/structs.h
@@ -117,7 +117,7 @@ typedef struct driver_info {
   optionlist *options;            /* Table of private options names */
   int    *options_count;          /* -> Number of entries in table */
   void   *options_block;          /* Points to default private block */
-  int     options_len;            /* Length of same in bytes */
+  size_t     options_len;         /* Length of same in bytes */
   void  (*init)(                  /* Initialization entry point */
     struct driver_instance *);
 } driver_info;
@@ -203,7 +203,7 @@ typedef struct transport_info {
   optionlist *options;            /* Table of private options names */
   int    *options_count;          /* -> Number of entries in table */
   void   *options_block;          /* Points to default private block */
-  int     options_len;            /* Length of same in bytes */
+  size_t     options_len;         /* Length of same in bytes */
   void (*init)(                   /* Initialization function */
     struct transport_instance *);
 /****/
@@ -315,7 +315,7 @@ typedef struct router_info {
   optionlist *options;            /* Table of private options names */
   int    *options_count;          /* -> Number of entries in table */
   void   *options_block;          /* Points to default private block */
-  int     options_len;            /* Length of same in bytes */
+  size_t     options_len;         /* Length of same in bytes */
   void (*init)(                   /* Initialization function */
     struct router_instance *);
 /****/
@@ -370,7 +370,7 @@ typedef struct auth_info {
   optionlist *options;            /* Table of private options names */
   int    *options_count;          /* -> Number of entries in table */
   void   *options_block;          /* Points to default private block */
-  int     options_len;            /* Length of same in bytes */
+  size_t     options_len;         /* Length of same in bytes */
   void (*init)(                   /* initialization function */
     struct auth_instance *);
 /****/
@@ -383,7 +383,7 @@ typedef struct auth_info {
     struct smtp_outblock *,       /* socket and output buffer */
     int,                          /* command timeout */
     uschar *,                     /* buffer for reading response */
-    int);                         /* sizeof buffer */
+    size_t);                      /* sizeof buffer */
   void (*version_report)(         /* diagnostic version reporting */
     FILE *);                      /* I/O stream to print to */
 } auth_info;

--- a/src/src/tlscert-gnu.c
+++ b/src/src/tlscert-gnu.c
@@ -362,7 +362,7 @@ for(index = 0;; index++)
     return g_err("gai", __FUNCTION__, ret);
 
   list = string_append_listele(list, sep,
-	    string_copyn(uri.data, uri.size));
+	    string_copyn(uri.data, (size_t)uri.size));
   }
 /*NOTREACHED*/
 
@@ -427,7 +427,7 @@ int fail;
 
 if (  (fail = gnutls_x509_crt_export((gnutls_x509_crt_t)cert,
 	GNUTLS_X509_FMT_DER, cp, &len)) != GNUTLS_E_SHORT_MEMORY_BUFFER
-   || !(cp = store_get((int)len))
+   || !(cp = store_get(len))
    || (fail = gnutls_x509_crt_export((gnutls_x509_crt_t)cert,
         GNUTLS_X509_FMT_DER, cp, &len))
    )

--- a/src/src/tlscert-openssl.c
+++ b/src/src/tlscert-openssl.c
@@ -104,7 +104,7 @@ return NULL;
 }
 
 static uschar *
-bio_string_copy(BIO * bp, int len)
+bio_string_copy(BIO * bp, size_t len)
 {
 uschar * cp = US"";
 len = len > 0 ? (int) BIO_get_mem_data(bp, &cp) : 0;
@@ -118,7 +118,7 @@ asn1_time_copy(const ASN1_TIME * asntime, uschar * mod)
 {
 uschar * s = NULL;
 BIO * bp = BIO_new(BIO_s_mem());
-int len;
+size_t len;
 
 if (!bp)
   return badalloc();
@@ -179,7 +179,7 @@ static uschar *
 x509_name_copy(X509_NAME * name)
 {
 BIO * bp = BIO_new(BIO_s_mem());
-int len_good;
+size_t len_good;
 
 if (!bp) return badalloc();
 
@@ -233,7 +233,7 @@ if (len < sizeof(txt))
 else
   len = 0;
 BIO_free(bp);
-return string_copynlc(txt, len);	/* lowercase */
+return string_copynlc(txt, (size_t)len);	/* lowercase */
 }
 
 uschar *
@@ -350,7 +350,7 @@ uschar osep = '\n';
 uschar * tag = US"";
 uschar * ele;
 int match = -1;
-int len;
+size_t len;
 
 if (!san) return NULL;
 
@@ -422,7 +422,7 @@ for (i = 0; i < adsnum; i++)
   if (ad && OBJ_obj2nid(ad->method) == NID_ad_OCSP)
     {
     uschar * ele = ASN1_STRING_data(ad->location->d.ia5);
-    int len =  ASN1_STRING_length(ad->location->d.ia5);
+    size_t len =  ASN1_STRING_length(ad->location->d.ia5);
     list = string_append_listele_n(list, sep, ele, len);
     }
   }
@@ -459,7 +459,7 @@ if (dps) for (i = 0; i < dpsnum; i++)
 	 )
 	{
 	uschar * ele = ASN1_STRING_data(np->d.uniformResourceIdentifier);
-	int len =  ASN1_STRING_length(np->d.uniformResourceIdentifier);
+	size_t len =  ASN1_STRING_length(np->d.uniformResourceIdentifier);
 	list = string_append_listele_n(list, sep, ele, len);
 	}
     }

--- a/src/src/transport.c
+++ b/src/src/transport.c
@@ -647,7 +647,7 @@ for (h = header_list; h != NULL; h = h->next) if (h->type != htype_old)
       uschar *s, *ss;
       while ((s = string_nextinlist(&list, &sep, NULL, 0)))
 	{
-	int len;
+	size_t len;
 
 	if (i == 0)
 	  if (!(s = expand_string(s)) && !expand_string_forcedfail)

--- a/src/src/transports/autoreply.c
+++ b/src/src/transports/autoreply.c
@@ -196,8 +196,8 @@ while (*s != 0)
   {
   uschar *error, *next;
   uschar *e = parse_find_address_end(s, FALSE);
-  int terminator = *e;
-  int start, end, domain, rc;
+  int domain, rc, terminator = *e;
+  size_t start, end;
 
   /* Temporarily terminate the string at the address end while extracting
   the operative address within. */

--- a/src/src/transports/pipe.c
+++ b/src/src/transports/pipe.c
@@ -478,8 +478,7 @@ if (expand_arguments)
     {
     address_item *ad;
     uschar *q = p + 14;
-    int size = Ustrlen(cmd) + 64;
-    int offset;
+    size_t offset, size = Ustrlen(cmd) + 64;
 
     if (p[-1] == '{') { q++; p--; }
 
@@ -1061,7 +1060,8 @@ if ((rc = child_close(pid, timeout)) != 0)
     else if (!ob->ignore_status)
       {
       uschar *ss;
-      int size, ptr, i;
+      size_t size, ptr;
+      int i;
 
       /* If temp_errors is "*" all codes are temporary. Initializion checks
       that it's either "*" or a list of numbers. If not "*", scan the list of

--- a/src/src/transports/smtp.c
+++ b/src/src/transports/smtp.c
@@ -1068,7 +1068,7 @@ if (is_esmtp && regex_match_and_setup(regex_AUTH, buffer, 0, -1))
       while (*p != 0)
 	{
 	int rc;
-	int len = Ustrlen(au->public_name);
+	size_t len = Ustrlen(au->public_name);
 	while (isspace(*p)) p++;
 
 	if (strncmpic(au->public_name, p, len) != 0 ||
@@ -1171,7 +1171,7 @@ Return	True on error, otherwise buffer has (possibly empty) terminated string
 */
 
 BOOL
-smtp_mail_auth_str(uschar *buffer, unsigned bufsize, address_item *addrlist,
+smtp_mail_auth_str(uschar *buffer, size_t bufsize, address_item *addrlist,
 		    smtp_transport_options_block *ob)
 {
 uschar *local_authenticated_sender = authenticated_sender;

--- a/src/src/transports/smtp.h
+++ b/src/src/transports/smtp.h
@@ -108,7 +108,7 @@ extern void smtp_transport_closedown(transport_instance *);
 extern int     smtp_auth(uschar *, unsigned, address_item *, host_item *,
 		 smtp_transport_options_block *, BOOL,
 		 smtp_inblock *, smtp_outblock *);
-extern BOOL    smtp_mail_auth_str(uschar *, unsigned,
+extern BOOL    smtp_mail_auth_str(uschar *, size_t,
 		 address_item *, smtp_transport_options_block *);
 
 #ifdef SUPPORT_SOCKS

--- a/src/src/verify.c
+++ b/src/src/verify.c
@@ -63,7 +63,8 @@ get_callout_cache_record(open_db *dbm_file, const uschar *key, uschar *type,
   int positive_expire, int negative_expire)
 {
 BOOL negative;
-int length, expire;
+size_t length;
+int expire;
 time_t now;
 dbdata_callout_cache *cache_record;
 
@@ -2409,8 +2410,8 @@ for (h = header_list; h != NULL && yield == OK; h = h->next)
     {
     uschar *ss = parse_find_address_end(s, FALSE);
     uschar *recipient, *errmess;
-    int terminator = *ss;
-    int start, end, domain;
+    int domain, terminator = *ss;
+    size_t start, end;
 
     /* Temporarily terminate the string at this point, and extract the
     operative address within, allowing group syntax. */
@@ -2571,8 +2572,8 @@ for (i = 0; i < recipients_count; i++)
       {
       uschar *ss = parse_find_address_end(s, FALSE);
       uschar *recipient,*errmess;
-      int terminator = *ss;
-      int start, end, domain;
+      int domain ,terminator = *ss;
+      size_t start, end;
 
       /* Temporarily terminate the string at this point, and extract the
       operative address within, allowing group syntax. */
@@ -2745,7 +2746,8 @@ for (i = 0; i < 3 && !done; i++)
 
       else
         {
-        int start, end, domain;
+        size_t start, end;
+        int domain;
         uschar *address = parse_extract_address(s, log_msgptr, &start, &end,
           &domain, FALSE);
 


### PR DESCRIPTION
It might be better to continue to dicuss this here instead of the mailing [list](https://lists.exim.org/lurker/message/20160424.131726.acbcd592.en.html) *(due to split of threads)*.
I took care to no use size_t when the signing bit might be required *(at least if I didn’t mistake)*.

This adds an additional *(but probably unnecessary)* safeguard. As well fix probable issues for 16 bits x86 machines *(in the case they use an ᴏꜱ already supported by exim)* .
At least this doesn’t hurt *(until all return values of`malloc()`are checked which I will fix too if you accept this)*.

Only core lib functions and the variables that use them are covered by this change *(definitely unnecessary for the others)*.  But I can add them too.

if despite testing, I did something wrong. ***Please tell it*** of course.