### PR TITLE
Do not call ldap_start_tls_s on ldapi:// connections.

### DIFF
--- a/src/src/lookups/ldap.c
+++ b/src/src/lookups/ldap.c
@@ -580,7 +580,7 @@ if (!lcp->bound ||
   {
   DEBUG(D_lookup) debug_printf("%sbinding with user=%s password=%s\n",
     (lcp->bound)? "re-" : "", user, password);
-  if (eldap_start_tls && !lcp->is_start_tls_called)
+  if (eldap_start_tls && !lcp->is_start_tls_called && !ldapi)
     {
 #if defined(LDAP_OPT_X_TLS) && !defined(LDAP_LIB_SOLARIS)
     /* The Oracle LDAP libraries (LDAP_LIB_TYPE=SOLARIS) don't support this.


### PR DESCRIPTION
The code already skips the initialisation of TLS on LDAP connections over unix
sockets but the call to ldap_start_tls_s is done nonetheless. This patch fixes it by adding the already existing boolean variable that is set to true if a connection is made with ldapi to the already existing condition around the call to ldap_start_tls_s.