### PR TITLE
replace keept with rotation

### DIFF
--- a/src/src/exicyclog.src
+++ b/src/src/exicyclog.src
@@ -232,16 +232,16 @@ $b
 # Now do the job. First remove the files that have "fallen off the bottom".
 # Look for both the compressed and uncompressed forms.
 
-if [ $keep -lt 10 ]; then keept=0$keep; else keept=$keep; fi;
+if [ $keep -lt 10 ]; then rotation=0$keep; else rotation=$keep; fi;
 
-if [ -f $mainlog.$keept ]; then $rm $mainlog.$keept; fi;
-if [ -f $mainlog.$keept.$suffix ]; then $rm $mainlog.$keept.$suffix; fi;
+if [ -f $mainlog.$rotation ]; then $rm $mainlog.$rotation; fi;
+if [ -f $mainlog.$rotation.$suffix ]; then $rm $mainlog.$rotation.$suffix; fi;
 
-if [ -f $rejectlog.$keept ]; then $rm $rejectlog.$keept; fi;
-if [ -f $rejectlog.$keept.$suffix ]; then $rm $rejectlog.$keept.$suffix; fi;
+if [ -f $rejectlog.$rotation ]; then $rm $rejectlog.$rotation; fi;
+if [ -f $rejectlog.$rotation.$suffix ]; then $rm $rejectlog.$rotation.$suffix; fi;
 
-if [ -f $paniclog.$keept ]; then $rm $paniclog.$keept; fi;
-if [ -f $paniclog.$keept.$suffix ]; then $rm $paniclog.$keept.$suffix; fi;
+if [ -f $paniclog.$rotation ]; then $rm $paniclog.$rotation; fi;
+if [ -f $paniclog.$rotation.$suffix ]; then $rm $paniclog.$rotation.$suffix; fi;
 
 # Now rename all the previous old files by increasing their numbers by 1.
 # When the number is less than 10, insert a leading zero.


### PR DESCRIPTION
Log rotate documentation does not actually give a term for this portion
of a filename, but to the extent that I can find a term, a number of
places call it a "rotation number".

Replacing keept which is inaccurate and misleading with rotation makes
the code a little easier to read.