### PR TITLE
spelling fixes

### DIFF
--- a/configs/config.samples/C047
+++ b/configs/config.samples/C047
@@ -37,11 +37,11 @@ This router has two advantages (for us):
 
 1. You can define the sender host addresses from which you will scan the spam.
 In my example there are ABC.DEF.GHI.JKL and MNO.PQR.STU.VWX (you have to
-substiute this by your real IP-Adresses).
+substiute this by your real IP-Addresses).
 
 2. The spamcheck router only runs in dependency of the existence of the
-.spamcheck file. So your users can decide whether or not they wont to use 
-Spamassassin. Thats important for protection of privacy in germany.
+.spamcheck file. So your users can decide whether or not they won't to use 
+Spamassassin. That's important for protection of privacy in germany.
 
 If you don't need this you can simplify the router, for example:
 
@@ -84,6 +84,6 @@ spamcheck:
 
 
 Put the router and the transport on the right places in your exim conf and send
-the daemon a HUP signal. Thats all.
+the daemon a HUP signal. That's all.
 
 - oliver

--- a/configs/config.samples/C051
+++ b/configs/config.samples/C051
@@ -124,7 +124,7 @@ lookup:
   driver = redirect
   address_data = GET_ADDRESS_DATA
   # data is intentionally left blank so that the router will decline
-  # we just want this router to do a lookup so the results are availble
+  # we just want this router to do a lookup so the results are available
   # for the other routers.
   data = 
 
@@ -202,7 +202,7 @@ remote_smtp:
   driver = smtp
 
 # Deliver to the mailbox specified in the LDAP directory. We make sure
-# that quota is obeyed, and we try to send a messge to the user if it
+# that quota is obeyed, and we try to send a message to the user if it
 # gets to over 85%.
 
 local_delivery:

--- a/configs/config.samples/F004
+++ b/configs/config.samples/F004
@@ -16,15 +16,15 @@ Message-Id: and Resent-Message-Id: headers to world-unique values.
 # headers to world-unique values.
 
 # Notes:
-# Change every occurence of "home.dom" to your home domain.
-# Change every occurence of "uniqie.remote.dom" to some unique value.
+# Change every occurrence of "home.dom" to your home domain.
+# Change every occurrence of "uniqie.remote.dom" to some unique value.
 
 # Unique values, as Vadik explained in his message to exim-users,
 # can be chosen in different ways:
 
 ### The ideal way is to choose "hostnames" in existing domains whose
 ### admins you know, and you will be sure that no hostname ending
-### with ".nonexistant.friendly.dom" will ever appear on this planet,
+### with ".nonexistent.friendly.dom" will ever appear on this planet,
 ### not even on someone else's message IDs.
 
 ### Another ideas include putting after your hostname things like:

--- a/doc/doc-docbook/Makefile
+++ b/doc/doc-docbook/Makefile
@@ -11,7 +11,7 @@ notarget:;    @echo "** You must specify a target, in the form x.y, where x is '
 # Generate all the documentation files...
 #
 ## removed info files as I cannot generate them -  spec.info filter.info
-## removed html files as superceded by new website code
+## removed html files as superseded by new website code
 everything:		spec.pdf 	spec.ps  	spec.txt \
 				filter.pdf 	filter.ps filter.txt \
 				exim.8

--- a/doc/doc-misc/Ext-mbx-locking
+++ b/doc/doc-misc/Ext-mbx-locking
@@ -228,7 +228,7 @@ BEZERK AND MMDF
 
      Locking in the traditional UNIX formats was largely dictated by
 the status quo in other applications; however, additional protection
-is added against inadvertantly running multiple instances of a
+is added against inadvertently running multiple instances of a
 c-client application on the same mail file.
 
      (1) c-client attempts to create a .lock file (mail file name with

--- a/doc/doc-src/FAQ.src
+++ b/doc/doc-src/FAQ.src
@@ -408,7 +408,7 @@ A0018: Recall that Exim does not keep separate queues for each domain, but
        a temporary error. Here are some possibilities:
 
        (1) The messages to \(aol.com)\ got put in your queue, but no previous
-       delivery attempt occured before you did the \-R-\. This might have been
+       delivery attempt occurred before you did the \-R-\. This might have been
        because of your settings of \queue_only_load\, \smtp_accept_queue\, or any
        other option that caused no immediate delivery attempt on arrival. If
        this is the case, you can try using \-qqR-\ instead of \-R-\.
@@ -1538,7 +1538,7 @@ A0089: This was a bad interaction between a change to the Linux kernel and some
        taken from Exim's change log:
 
        When Exim is receiving multiple messages on a single connection, and
-       spinning off delivery processess, it sets the SIGCHLD signal handling to
+       spinning off delivery processes, it sets the SIGCHLD signal handling to
        SIG_IGN, because it doesn't want to wait for these processes. However,
        because on some OS this didn't work, it also has a paranoid call to
        \^waitpid()^\ in the loop to reap any children that have finished. Some
@@ -2917,7 +2917,7 @@ Q0419: I have some obsolete domains which people have been warned not to use
        any more. How can I arrange to delete any mail that is sent to them?
 
 A0419: To reject them at SMTP time, with a customized error message, place
-       statments like this in the ACL:
+       statements like this in the ACL:
 
 ==>      deny message = The domain $domain is obsolete
               domains = lsearch;/etc/exim/obsolete.domains
@@ -5122,7 +5122,7 @@ A1001: Splitting the spool directory has most benefit if there are times when
        up earlier on some types of file system, compared with others.
 
        Exim was not designed for handling large queues. If you are in an
-       enviroment where lots of messages remain on the queue for long periods
+       environment where lots of messages remain on the queue for long periods
        of time, consider implementing a back up host to which you pass these
        messages, so that the main host's queue remains short. You can use
        \fallback_hosts\ to do this, or a router that is conditional on
@@ -6612,7 +6612,7 @@ Q9604: I get the \*too many open files*\ error especially when a lot of messages
        land for Majordomo at the same time.
 
 A9604: The problem appears to be the number of open files the system can
-       handle. This is changable by using the proc filesystem. To your
+       handle. This is changeable by using the proc filesystem. To your
        \(/etc/rc.d/rc.local)\ file append something like the following:
 
 ==>      # Now System is up, Modify kernel parameters for max open etc.

--- a/doc/doc-txt/NewStuff
+++ b/doc/doc-txt/NewStuff
@@ -829,7 +829,7 @@ Version 4.68
     longest line that was received as part of the message, not counting the
     line termination character(s).
 
- 7. Host lists can now include +ignore_defer and +include_defer, analagous to
+ 7. Host lists can now include +ignore_defer and +include_defer, analogous to
     +ignore_unknown and +include_unknown. These options should be used with
     care, probably only in non-critical host lists such as whitelists.
 

--- a/doc/doc-txt/dbm.discuss.txt
+++ b/doc/doc-txt/dbm.discuss.txt
@@ -223,7 +223,7 @@ files in other formats that are created by other programs.
 Berkeley DB 4.x
 ---------------
 
-The 4.x series is a developement of the 2.x and 3.x series, and the above
+The 4.x series is a development of the 2.x and 3.x series, and the above
 comments apply.
 
 

--- a/src/README.UPDATING
+++ b/src/README.UPDATING
@@ -63,7 +63,7 @@ Exim version 4.83
 -----------------
 
  * SPF condition results renamed "permerror" and "temperror".  The old
-   names are still accepted for back-compatability, for this release.
+   names are still accepted for back-compatibility, for this release.
 
  * TLS details are now logged on rejects, subject to log selectors.
 
@@ -104,7 +104,7 @@ Exim version 4.80
    upgrading, then lock the message, replace the new-lines that should be part
    of the -tls_peerdn line with the two-character sequence \n and then unlock
    the message.  No tool has been provided as we believe this is a rare
-   occurence.
+   occurrence.
 
  * For OpenSSL, SSLv2 is now disabled by default.  (GnuTLS does not support
    SSLv2).  RFC 6176 prohibits SSLv2 and some informal surveys suggest no
@@ -317,7 +317,7 @@ Exim version 4.70
 -----------------
 
 1. Experimental Yahoo! Domainkeys support has been dropped in this release.
-It has been superceded by a native implementation of its successor DKIM.
+It has been superseded by a native implementation of its successor DKIM.
 
 2. Up to version 4.69, Exim came with an embedded version of the PCRE library.
 As of 4.70, this is no longer the case. To compile Exim, you will need PCRE

--- a/src/scripts/Configure-os.h
+++ b/src/scripts/Configure-os.h
@@ -28,7 +28,7 @@ then    echo ""
 fi
 rm -f os.h
 
-# In order to accomodate for the fudge below, copy the file instead of
+# In order to accommodate for the fudge below, copy the file instead of
 # symlinking it. Otherwise we pollute the clean copy with the fudge.
 cp -p ../OS/os.h-$os os.h || exit 1
 

--- a/src/src/auths/gsasl_exim.c
+++ b/src/src/auths/gsasl_exim.c
@@ -272,7 +272,7 @@ auth_gsasl_server(auth_instance *ablock, uschar *initial_data)
   gsasl_property_set(sctx, GSASL_QOPS, "qop-auth");
 #ifdef SUPPORT_TLS
   if (tls_channelbinding_b64) {
-    /* Some auth mechanisms can ensure that both sides are talking withing the
+    /* Some auth mechanisms can ensure that both sides are talking within the
     same security context; for TLS, this means that even if a bad certificate
     has been accepted, they remain MitM-proof because both sides must be within
     the same negotiated session; if someone is terminating one session and

--- a/src/src/dane-openssl.c
+++ b/src/src/dane-openssl.c
@@ -412,7 +412,7 @@ set_issuer_name(X509 *cert, AUTHORITY_KEYID *akid)
 X509_NAME *name = akid_issuer_name(akid);
 
 /*
- * If subject's akid specifies an authority key identifer issuer name, we
+ * If subject's akid specifies an authority key identifier issuer name, we
  * must use that.
  */
 return X509_set_issuer_name(cert,

--- a/src/src/exim.c
+++ b/src/src/exim.c
@@ -2773,7 +2773,7 @@ for (i = 1; i < argc; i++)
 
 #ifdef SUPPORT_TLS
     /* -MCt: similar to -MCT below but the connection is still open
-    via a proxy proces which handles the TLS context and coding.
+    via a proxy process which handles the TLS context and coding.
     Require three arguments for the proxied local address and port,
     and the TLS cipher.  */
 
@@ -3782,7 +3782,7 @@ if (running_in_test_harness) smtputf8_advertise_hosts = NULL;
 is a failure. It leaves the configuration file open so that the subsequent
 configuration data for delivery can be read if needed.
 
-NOTE: immediatly after opening the configuration file we change the working
+NOTE: immediately after opening the configuration file we change the working
 directory to "/"! Later we change to $spool_directory. We do it there, because
 during readconf_main() some expansion takes place already. */
 

--- a/src/src/expand.c
+++ b/src/src/expand.c
@@ -4625,7 +4625,7 @@ while (*s != 0)
           (void)sscanf(CS now,"%u",&inow);
           (void)sscanf(CS daystamp,"%u",&iexpire);
 
-          /* When "iexpire" is < 7, a "flip" has occured.
+          /* When "iexpire" is < 7, a "flip" has occurred.
              Adjust "inow" accordingly. */
           if ( (iexpire < 7) && (inow >= 993) ) inow = 0;
 
@@ -7171,7 +7171,7 @@ while (*s != 0)
         continue;
         }
 
-      /* Handle time period formating */
+      /* Handle time period formatting */
 
       case EOP_TIME_EVAL:
         {

--- a/src/src/globals.h
+++ b/src/src/globals.h
@@ -382,7 +382,7 @@ extern BOOL    disable_ipv6;           /* Don't do any IPv6 things */
 extern BOOL    disable_logging;        /* Disables log writing when TRUE */
 
 #ifndef DISABLE_DKIM
-extern BOOL    dkim_collect_input;     /* Runtime flag that tracks wether SMTP input is fed to DKIM validation */
+extern BOOL    dkim_collect_input;     /* Runtime flag that tracks whether SMTP input is fed to DKIM validation */
 extern uschar *dkim_cur_signer;        /* Expansion variable, holds the current "signer" domain or identity during a acl_smtp_dkim run */
 extern BOOL    dkim_disable_verify;    /* Set via ACL control statement. When set, DKIM verification is disabled for the current message */
 extern int     dkim_key_length;        /* Expansion variable, length of signing key in bits */

--- a/src/src/lookups/oracle.c
+++ b/src/src/lookups/oracle.c
@@ -420,7 +420,7 @@ while (cda->rc != NO_DATA_FOUND)  /* Loop for each row */
     result = string_catn(result, &ssize, &offset, s, slen);
     result = string_catn(result, &ssize, &offset, US"=", 1);
 
-    /* int and float type wont ever need escaping. Otherwise, quote the value
+    /* int and float type won't ever need escaping. Otherwise, quote the value
     if it contains spaces or is empty. */
 
     if (desc[i].dbtype != INT_TYPE && desc[i].dbtype != FLOAT_TYPE &&

--- a/src/src/malware.c
+++ b/src/src/malware.c
@@ -1801,7 +1801,7 @@ if (!malware_ok)
       and the [ ] marker.
       [+] - not infected
       [L] - infected
-      [E] - some error occured
+      [E] - some error occurred
       Such marker follows the first non-escaped TAB.  */
       if (  (  !ava_re_clean
             && !(ava_re_clean = m_pcre_compile(ava_re_clean_str, &errstr)))

--- a/src/src/rda.c
+++ b/src/src/rda.c
@@ -492,7 +492,7 @@ return TRUE;
 /* This function is passed a forward list string (unexpanded) or the name of a
 file (unexpanded) whose contents are the forwarding list. The list may in fact
 be a filter program if it starts with "#Exim filter" or "#Sieve filter". Other
-types of filter, with different inital tag strings, may be introduced in due
+types of filter, with different initial tag strings, may be introduced in due
 course.
 
 The job of the function is to process the forwarding list or filter. It is

--- a/src/src/readconf.c
+++ b/src/src/readconf.c
@@ -1090,7 +1090,7 @@ for (;;)
 
   /* Handle conditionals, which are also applied to physical lines. Conditions
   are of the form ".ifdef ANYTEXT" and are treated as true if any macro
-  expansion occured on the rest of the line. A preliminary test for the leading
+  expansion occurred on the rest of the line. A preliminary test for the leading
   '.' saves effort on most lines. */
 
   if (*ss == '.')

--- a/src/src/routers/accept.c
+++ b/src/src/routers/accept.c
@@ -105,7 +105,7 @@ DEBUG(D_route) debug_printf("%s router called for %s\n  domain = %s\n",
 rc = rf_get_errors_address(addr, rblock, verify, &errors_to);
 if (rc != OK) return rc;
 
-/* Set up the additional and removeable headers for the address. */
+/* Set up the additional and removable headers for the address. */
 
 rc = rf_get_munge_headers(addr, rblock, &extra_headers, &remove_headers);
 if (rc != OK) return rc;

--- a/src/src/routers/dnslookup.c
+++ b/src/src/routers/dnslookup.c
@@ -422,7 +422,7 @@ else if (ob->check_secondary_mx && !testflag(addr, af_local_host_removed))
 rc = rf_get_errors_address(addr, rblock, verify, &addr->prop.errors_address);
 if (rc != OK) return rc;
 
-/* Set up the additional and removeable headers for this address. */
+/* Set up the additional and removable headers for this address. */
 
 rc = rf_get_munge_headers(addr, rblock, &addr->prop.extra_headers,
   &addr->prop.remove_headers);

--- a/src/src/routers/ipliteral.c
+++ b/src/src/routers/ipliteral.c
@@ -168,7 +168,7 @@ addr->host_list = h;
 rc = rf_get_errors_address(addr, rblock, verify, &addr->prop.errors_address);
 if (rc != OK) return rc;
 
-/* Set up the additional and removeable headers for this address. */
+/* Set up the additional and removable headers for this address. */
 
 rc = rf_get_munge_headers(addr, rblock, &addr->prop.extra_headers,
   &addr->prop.remove_headers);

--- a/src/src/routers/iplookup.c
+++ b/src/src/routers/iplookup.c
@@ -389,7 +389,7 @@ addr->child_count++;
 new_addr->next = *addr_new;
 *addr_new = new_addr;
 
-/* Set up the errors address, if any, and the additional and removeable headers
+/* Set up the errors address, if any, and the additional and removable headers
 for this new address. */
 
 rc = rf_get_errors_address(addr, rblock, verify, &new_addr->prop.errors_address);

--- a/src/src/routers/manualroute.c
+++ b/src/src/routers/manualroute.c
@@ -361,7 +361,7 @@ while (*options != 0)
 rc = rf_get_errors_address(addr, rblock, verify, &addr->prop.errors_address);
 if (rc != OK) return rc;
 
-/* Set up the additional and removeable headers for this address. */
+/* Set up the additional and removable headers for this address. */
 
 rc = rf_get_munge_headers(addr, rblock, &addr->prop.extra_headers,
   &addr->prop.remove_headers);

--- a/src/src/spf.c
+++ b/src/src/spf.c
@@ -90,7 +90,7 @@ int spf_process(const uschar **listptr, uschar *spf_envelope_sender, int action)
   };
 
   if (SPF_request_set_env_from(spf_request, CS spf_envelope_sender)) {
-    /* Invalid sender address. This should be a real rare occurence */
+    /* Invalid sender address. This should be a real rare occurrence */
     rc = SPF_RESULT_PERMERROR;
     goto SPF_EVALUATE;
   }

--- a/src/src/tls-gnu.c
+++ b/src/src/tls-gnu.c
@@ -1175,7 +1175,7 @@ if (!exim_gnutls_base_init_done)
   DEBUG(D_tls)
     {
     gnutls_global_set_log_function(exim_gnutls_logger_cb);
-    /* arbitrarily chosen level; bump upto 9 for more */
+    /* arbitrarily chosen level; bump up to 9 for more */
     gnutls_global_set_log_level(EXIM_GNUTLS_LIBRARY_LOG_LEVEL);
     }
 #endif
@@ -2164,7 +2164,7 @@ Only used by the server-side TLS.
 
 This feeds DKIM and should be used for all message-body reads.
 
-Arguments:  lim		Maximum amount to read/bufffer
+Arguments:  lim		Maximum amount to read/buffer
 Returns:    the next character or EOF
 */
 

--- a/src/src/transports/smtp.c
+++ b/src/src/transports/smtp.c
@@ -2258,7 +2258,7 @@ if (sx->peer_offered & PEER_OFFERED_SIZE)
   }
 
 #ifndef DISABLE_PRDR
-/* If it supports Per-Recipient Data Reponses, and we have omre than one recipient,
+/* If it supports Per-Recipient Data Responses, and we have more than one recipient,
 request that */
 
 sx->prdr_active = FALSE;
@@ -3286,7 +3286,7 @@ connection if there are several waiting, provided we haven't already sent so
 many as to hit the configured limit. The function transport_check_waiting looks
 for a waiting message and returns its id. Then transport_pass_socket tries to
 set up a continued delivery by passing the socket on to another process. The
-variable send_rset is FALSE if a message has just been successfully transfered.
+variable send_rset is FALSE if a message has just been successfully transferred.
 
 If we are already sending down a continued channel, there may be further
 addresses not yet delivered that are aimed at the same host, but which have not

--- a/test/README
+++ b/test/README
@@ -1037,7 +1037,7 @@ Lines in client scripts are of two kinds:
 (5) Otherwise, the line is an input line line that is sent to the server. Any
     occurrences of \r and \n in the line are turned into carriage return and
     linefeed, respectively. This is used for testing PIPELINING.
-    Any sequences of \x followed by two hex digits are converted to the equvalent
+    Any sequences of \x followed by two hex digits are converted to the equivalent
     byte value.  Any other character following a \ is sent verbatim.
     The line is sent with a trailing "\r\n".
 

--- a/test/aux-fixed/exim-ca/README
+++ b/test/aux-fixed/exim-ca/README
@@ -22,7 +22,7 @@ by that name; those in the "expired" ones are out-of-date (the
 rest expire in 2038).  The "1" and "2" systems/certs have
 equivalent properties.
 
-In each certicate subdir: the ".db" files are NSS version of the cert,
+In each certificate subdir: the ".db" files are NSS version of the cert,
 the ".pem", ".key" and ".unlocked.key" are usable by OpenSSL (the
 ca_chain.pem being a copy of the CA public information and signer
 public information).

--- a/test/runtest
+++ b/test/runtest
@@ -2061,7 +2061,7 @@ elsif (/^millisleep\s+(.*)$/)
 
 
 # The "munge" command selects one of a hardwired set of test-result modifications
-# to be made before result compares are run agains the golden set.  This lets
+# to be made before result compares are run against the golden set.  This lets
 # us account for test-system dependent things which only affect a few, but known,
 # test-cases.
 # Currently only the last munge takes effect.


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.