### PR TITLE
Log overall response message when using PRDR

### DIFF
--- a/test/log/4550
+++ b/test/log/4550
@@ -1,6 +1,6 @@
 1999-03-02 09:44:33 10HmaX-0005vi-00 <= CALLER@myhost.test.ex U=CALLER P=local S=sss
 1999-03-02 09:44:33 10HmaX-0005vi-00 ** baduser@test.ex R=client T=send_to_server H=ip4.ip4.ip4.ip4 [ip4.ip4.ip4.ip4]: PRDR error after DATA: 550 PRDR R=<baduser@test.ex> refusal
-1999-03-02 09:44:33 10HmaX-0005vi-00 => okuser@test.ex R=client T=send_to_server H=ip4.ip4.ip4.ip4 [ip4.ip4.ip4.ip4] PRDR C="250 PRDR R=<okuser@test.ex> acceptance"
+1999-03-02 09:44:33 10HmaX-0005vi-00 => okuser@test.ex R=client T=send_to_server H=ip4.ip4.ip4.ip4 [ip4.ip4.ip4.ip4] PRDR C="250 PRDR R=<okuser@test.ex> acceptance\\n250 id=10HmbA-0005vi-00 message accepted for some recipients"
 1999-03-02 09:44:33 10HmaY-0005vi-00 <= <> R=10HmaX-0005vi-00 U=EXIMUSER P=local S=sss
 1999-03-02 09:44:33 10HmaY-0005vi-00 => CALLER@myhost.test.ex R=client T=send_to_server H=ip4.ip4.ip4.ip4 [ip4.ip4.ip4.ip4] C="250 OK id=10HmaZ-0005vi-00"
 1999-03-02 09:44:33 10HmaY-0005vi-00 Completed

--- a/test/log/5510
+++ b/test/log/5510
@@ -1,16 +1,16 @@
 1999-03-02 09:44:33 10HmaX-0005vi-00 <= userx@test.ex U=CALLER P=local S=sss
-1999-03-02 09:44:33 10HmaX-0005vi-00 => usery@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] PRDR C="250 first rcpt was good"
-1999-03-02 09:44:33 10HmaX-0005vi-00 -> userz@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] PRDR C="250 second rcpt was good"
+1999-03-02 09:44:33 10HmaX-0005vi-00 => usery@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] PRDR C="250 first rcpt was good\\n250 OK, overall"
+1999-03-02 09:44:33 10HmaX-0005vi-00 -> userz@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] PRDR C="250 second rcpt was good\\n250 OK, overall"
 1999-03-02 09:44:33 10HmaX-0005vi-00 Completed
 1999-03-02 09:44:33 10HmaY-0005vi-00 <= userx@test.ex U=CALLER P=local S=sss
 1999-03-02 09:44:33 10HmaY-0005vi-00 => user2.1@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] C="250 OK got that"
 1999-03-02 09:44:33 10HmaY-0005vi-00 -> user2.2@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] C="250 OK got that"
 1999-03-02 09:44:33 10HmaY-0005vi-00 Completed
 1999-03-02 09:44:33 10HmaZ-0005vi-00 <= userx@test.ex U=CALLER P=local S=sss
-1999-03-02 09:44:33 10HmaZ-0005vi-00 => usery@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] PRDR C="250 first rcpt was good"
+1999-03-02 09:44:33 10HmaZ-0005vi-00 => usery@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] PRDR C="250 first rcpt was good\\n250 OK, overall"
 1999-03-02 09:44:33 10HmaZ-0005vi-00 == userz@test.ex R=r0 T=t1 defer (0) H=127.0.0.1 [127.0.0.1]: PRDR error after DATA: 450 cannot handle second rcpt right now
 1999-03-02 09:44:33 10HmbA-0005vi-00 <= <> U=CALLER P=local S=sss
-1999-03-02 09:44:33 10HmbA-0005vi-00 => userp@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] PRDR C="250 first rcpt was good"
+1999-03-02 09:44:33 10HmbA-0005vi-00 => userp@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1] PRDR C="250 first rcpt was good\\n250 OK, overall"
 1999-03-02 09:44:33 10HmbA-0005vi-00 ** userq@test.ex R=r0 T=t1 H=127.0.0.1 [127.0.0.1]: PRDR error after DATA: 550 second rcpt does not like content
 1999-03-02 09:44:33 10HmbA-0005vi-00 Frozen (delivery error message)
 1999-03-02 09:44:33 10HmaZ-0005vi-00 == userz@test.ex routing defer (-51): retry time not reached

--- a/test/log/5591
+++ b/test/log/5591
@@ -1,4 +1,4 @@
 1999-03-02 09:44:33 10HmaX-0005vi-00 <= sender@dom U=root P=local-bsmtp S=sss for usery@testhost.test.ex userz@testhost.test.ex
-1999-03-02 09:44:33 10HmaX-0005vi-00 => usery@testhost.test.ex R=to_server T=remote_smtp H=127.0.0.1 [127.0.0.1] PRDR K C="250 first rcpt was good"
-1999-03-02 09:44:33 10HmaX-0005vi-00 -> userz@testhost.test.ex R=to_server T=remote_smtp H=127.0.0.1 [127.0.0.1] PRDR K C="250 second rcpt was good"
+1999-03-02 09:44:33 10HmaX-0005vi-00 => usery@testhost.test.ex R=to_server T=remote_smtp H=127.0.0.1 [127.0.0.1] PRDR K C="250 first rcpt was good\\n250 OK, overall"
+1999-03-02 09:44:33 10HmaX-0005vi-00 -> userz@testhost.test.ex R=to_server T=remote_smtp H=127.0.0.1 [127.0.0.1] PRDR K C="250 second rcpt was good\\n250 OK, overall"
 1999-03-02 09:44:33 10HmaX-0005vi-00 Completed


### PR DESCRIPTION
When using PRDR, the "C=" log message only contains the PRDR response
and the overall response message (that typically contains the remote
message reference) is not logged.

The logged response is already capable of containing multiple lines
in the event that there is a multi-line response, so this change
appends the overall response to the PRDR response with a newline
between them.

The "C=" log message will therefore contain both responses:
=> ... PRDR C="250 PRDR R=<postmaster@example.com> acceptance\\n250 id=1eiQ9X-0005Ra-I3 message accepted" QT=3s DT=0s
-> ... PRDR C="250 PRDR R=<postmaster@example.net> acceptance\\n250 id=1eiQ9X-0005Ra-I3 message accepted" QT=3s DT=0s