### PR TITLE
Add support for passing an open read-only file descriptor to clamd.

### DIFF
--- a/doc/doc-docbook/spec.xfpt
+++ b/doc/doc-docbook/spec.xfpt
@@ -31991,10 +31991,19 @@ Any further elements are per-server (non-global) options.
 These per-server options are supported:
 .code
 retry=<timespec>	Retry on connect fail
+fdpass						Pass an open read-only file descriptor to clamd. Ignored for TCP sockets.
 .endd
 
 The &`retry`& option specifies a time after which a single retry for
 a failed connect is made.  The default is to not retry.
+
+The &`fdpass`& option requests to use the zFILDES command to send an open
+read-only file descriptor to clamd. The advantage is, that clamd does not need
+any special access permissions on either Exim's scan directory or the files it
+should scan. This allows users to further restrict clamd enhancing the security
+of the system by disallowing clamd to open arbitrary files by its own. The
+disadvantage is, that clamd does not know the name of the file it scans. It will
+log a string like "fd[10]" instead of the file's name.
 
 If a Unix socket file is specified, only one server is supported.
 

--- a/src/src/malware.c
+++ b/src/src/malware.c
@@ -105,6 +105,7 @@ typedef struct clamd_address {
   uschar * hostspec;
   unsigned tcp_port;
   unsigned retry;
+  BOOL fdpass;
 } clamd_address;
 #endif
 
@@ -495,6 +496,7 @@ clamd_option(clamd_address * cd, const uschar * optstr, int * subsep)
 uschar * s;
 
 cd->retry = 0;
+cd->fdpass = FALSE;
 while ((s = string_nextinlist(&optstr, subsep, NULL, 0)))
   if (Ustrncmp(s, "retry=", 6) == 0)
     {
@@ -502,6 +504,10 @@ while ((s = string_nextinlist(&optstr, subsep, NULL, 0)))
     if (sec < 0)
       return FAIL;
     cd->retry = sec;
+    }
+  else if (Ustrncmp(s, "fdpass", 6) == 0)
+    {
+      cd->fdpass = TRUE;
     }
   else
     return FAIL;
@@ -1389,16 +1395,24 @@ badseek:  err = errno;
 #ifndef DISABLE_MAL_CLAM
     case M_CLAMD: /* "clamd" scanner type ----------------------------------- */
       {
-/* This code was originally contributed by David Saez */
-/* There are three scanning methods available to us:
-*  (1) Use the SCAN command, pointing to a file in the filesystem
-*  (2) Use the STREAM command, send the data on a separate port
-*  (3) Use the zINSTREAM command, send the data inline
-* The zINSTREAM command was introduced with ClamAV 0.95, which marked
-* STREAM deprecated; see: http://wiki.clamav.net/bin/view/Main/UpgradeNotes095
-* In Exim, we use SCAN if using a Unix-domain socket or explicitly told that
-* the TCP-connected daemon is actually local; otherwise we use zINSTREAM
-* See Exim bug 926 for details.  */
+      /* This code was originally contributed by David Saez
+       * Exim uses the following methods to pass files (or a kind of pointer to
+       * them) to clamd:
+       *
+       * If Unix-Domain sockets are used:
+       * (1) The SCAN command, pointing to a file in the filesystem.
+       * (2) The zFILDES command, sending an open read-only file descriptor.
+       * Using zFILDES must be requested explicitly be the user using the
+       * per-server option "fdpass". The default is to use the SCAN command.
+       *
+       * If TCP sockets are used:
+       * (1) The SCAN command, pointing to a file in the filesystem.
+       * (2) The zINSTREAM command, sending the data of the file inline over the
+       *     same TCP connection.
+       * Using SCAN must be requested explicitly be the user using the
+       * per-server option "local" to tell Exim that although a TCP socket is
+       * used, clamd has direct access to the filesystem. The default is to use
+       * the zINSTREAM command. */
 
       uschar *p, *vname, *result_tag;
       int bread=0;
@@ -1410,6 +1424,7 @@ badseek:  err = errno;
       off_t fsize;
       unsigned int fsize_uint;
       BOOL use_scan_command = FALSE;
+      BOOL use_fildes_command = FALSE;
       clamd_address * cv[MAX_CLAMD_SERVERS];
       int num_servers = 0;
       uint32_t send_size, send_final_zeroblock;
@@ -1437,6 +1452,8 @@ badseek:  err = errno;
 	if (clamd_option(cd, sublist, &subsep) != OK)
 	  return m_panic_defer(scanent, NULL,
 	    string_sprintf("bad option '%s'", scanner_options));
+  /* Unix sockets can use fdpass, so enable it if the user requests it. */
+  use_fildes_command = cd->fdpass;
 	cv[0] = cd;
 	}
       else
@@ -1514,8 +1531,16 @@ badseek:  err = errno;
 	{ cmd_str.data = US"zINSTREAM"; cmd_str.len = 10; }
       else
 	{
-	cmd_str.data = string_sprintf("SCAN %s\n", eml_filename);
-	cmd_str.len = Ustrlen(cmd_str.data);
+    if (use_fildes_command)
+      {
+      cmd_str.data = US"zFILDES";
+      cmd_str.len = 8; /* including the terminating \0 */
+      }
+    else
+      {
+      cmd_str.data = string_sprintf("SCAN %s\n", eml_filename);
+      cmd_str.len = Ustrlen(cmd_str.data);
+      }
 	}
 
       /* We have some network servers specified */
@@ -1686,10 +1711,52 @@ b_seek:   err = errno;
 	    scanner_name, scanner_options);
 
 	if (cmd_str.len)
+    {
 	  if (send(sock, cmd_str.data, cmd_str.len, 0) < 0)
 	    return m_panic_defer_3(scanent, CUS callout_address,
 	      string_sprintf("unable to write to socket (%s)", strerror(errno)),
 	      sock);
+
+    if (use_fildes_command)
+      {
+      int eml_fd = 0;
+      if ((eml_fd = open(CS eml_filename, O_RDONLY)) < 0)
+        {
+        return m_panic_defer_3(scanent, NULL, string_sprintf("can't open spool file %s: %s", eml_filename, strerror(errno)), sock);
+        }
+
+      /* buffer for one file descriptor */
+      char buf[CMSG_SPACE(sizeof(eml_fd))];
+
+      char iobuf = 0;
+      struct iovec io;
+      memset(&io, 0, sizeof(io));
+      io.iov_base = &iobuf;
+      io.iov_len = sizeof(iobuf);
+
+      struct msghdr msg;
+      memset(&msg, 0, sizeof(msg));
+      msg.msg_iov = &io;
+      msg.msg_iovlen = 1;
+      msg.msg_control = buf;
+      msg.msg_controllen = sizeof(buf);
+
+      struct cmsghdr *cmsg;
+      cmsg = CMSG_FIRSTHDR(&msg);
+      cmsg->cmsg_level = SOL_SOCKET;
+      cmsg->cmsg_type = SCM_RIGHTS;
+      cmsg->cmsg_len = CMSG_LEN(sizeof(eml_fd));
+      *(int*)CMSG_DATA(cmsg) = eml_fd;
+
+      if (sendmsg(sock, &msg, 0) < 0)
+        {
+        close(eml_fd);
+        return m_panic_defer_3(scanent, CUS callout_address, string_sprintf("unable to send file descriptor to socket (%s)", strerror(errno)), sock);
+        }
+
+      close(eml_fd);
+      }
+    }
 
 	/* Do not shut down the socket for writing; a user report noted that
 	 * clamd 0.70 does not react well to this. */


### PR DESCRIPTION
Additionally to the SCAN command clamd supports the zFILDES command to pass an
already open read-only file descriptor for the file to be scanned. The
advantage is that clamd does not need any special file system permissions to
scan files in exim's scan directory. The disadvantage is that clamd does not
know the file's name and will log a line like "fd[10]: OK".

----
I tried to follow the coding style of malware.c but I may have failed, because there is actually no consistent coding style.