### PR TITLE
src/src/lookups/dnsdb.c: resolve possible null pointer dereference

### DIFF
--- a/src/src/lookups/dnsdb.c
+++ b/src/src/lookups/dnsdb.c
@@ -547,10 +547,6 @@ while ((domain = string_nextinlist(&keystring, &sep, NULL, 0)))
 
   }        /* Loop for list of domains */
 
-/* Reclaim unused memory */
-
-store_reset(yield->s + yield->ptr + 1);
-
 /* If yield NULL we have not found anything. Otherwise, insert the terminating
 zero and return the result. */
 
@@ -559,6 +555,10 @@ dns_retry = save_retry;
 dns_init(FALSE, FALSE, FALSE);	/* clear the dnssec bit for getaddrbyname */
 
 if (!yield || !yield->ptr) return failrc;
+
+/* Reclaim unused memory */
+
+store_reset(yield->s + yield->ptr + 1);
 
 *result = string_from_gstring(yield);
 return OK;


### PR DESCRIPTION
found by cppcheck

[src/src/lookups/dnsdb.c:561] -> [src/src/lookups/dnsdb.c:552]: (warning) Either the condition '!yield' is redundant or there is possible null pointer dereference: yield.

