### PR TITLE
Fix uClibc build

### DIFF
--- a/src/OS/os.h-Linux
+++ b/src/OS/os.h-Linux
@@ -94,5 +94,9 @@ then change the 0 to 1 in the next block. */
 /* inotify(7) etc syscalls */
 #define EXIM_HAVE_INOTIFY
 
+/* Needed for uClibc */
+#ifndef NS_MAXMSG
+# define NS_MAXMSG 65535
+#endif
 
 /* End */


### PR DESCRIPTION
Fixes a build error wuth uClibc:

structs.h:757:18: error: ‘NS_MAXMSG’ undeclared here (not in a function); did you mean ‘N_MASC’?
   uschar  answer[NS_MAXMSG];      /* the answer itself */
