### PR TITLE
call_radius: fix compilation due to incorrect usage of string_sprintf

### DIFF
--- a/src/src/auths/call_radius.c
+++ b/src/src/auths/call_radius.c
@@ -115,16 +115,16 @@ if (rc_read_config(RADIUS_CONFIG_FILE) != 0)
   *errptr = string_sprintf("RADIUS: can't open %s", RADIUS_CONFIG_FILE);
 
 else if (rc_read_dictionary(rc_conf_str("dictionary")) != 0)
-  *errptr = string_sprintf("RADIUS: can't read dictionary");
+  *errptr = US("RADIUS: can't read dictionary");
 
 else if (rc_avpair_add(&send, PW_USER_NAME, user, 0) == NULL)
-  *errptr = string_sprintf("RADIUS: add user name failed\n");
+  *errptr = US("RADIUS: add user name failed");
 
 else if (rc_avpair_add(&send, PW_USER_PASSWORD, CS radius_args, 0) == NULL)
-  *errptr = string_sprintf("RADIUS: add password failed\n");
+  *errptr = US("RADIUS: add password failed");
 
 else if (rc_avpair_add(&send, PW_SERVICE_TYPE, &service, 0) == NULL)
-  *errptr = string_sprintf("RADIUS: add service type failed\n");
+  *errptr = US("RADIUS: add service type failed");
 
 #else  /* RADIUS_LIB_RADIUSCLIENT unset => RADIUS_LIB_RADIUSCLIENT2 */
 
@@ -132,17 +132,17 @@ if ((h = rc_read_config(RADIUS_CONFIG_FILE)) == NULL)
   *errptr = string_sprintf("RADIUS: can't open %s", RADIUS_CONFIG_FILE);
 
 else if (rc_read_dictionary(h, rc_conf_str(h, "dictionary")) != 0)
-  *errptr = string_sprintf("RADIUS: can't read dictionary");
+  *errptr = US("RADIUS: can't read dictionary");
 
 else if (rc_avpair_add(h, &send, PW_USER_NAME, user, Ustrlen(user), 0) == NULL)
-  *errptr = string_sprintf("RADIUS: add user name failed\n");
+  *errptr = US("RADIUS: add user name failed");
 
 else if (rc_avpair_add(h, &send, PW_USER_PASSWORD, CS radius_args,
     Ustrlen(radius_args), 0) == NULL)
-  *errptr = string_sprintf("RADIUS: add password failed\n");
+  *errptr = US("RADIUS: add password failed");
 
 else if (rc_avpair_add(h, &send, PW_SERVICE_TYPE, &service, 0, 0) == NULL)
-  *errptr = string_sprintf("RADIUS: add service type failed\n");
+  *errptr = US("RADIUS: add service type failed");
 
 #endif  /* RADIUS_LIB_RADIUSCLIENT */
 


### PR DESCRIPTION
Since f3ebb786e451da973560f1c9d8cdb151d25108b5, string_sprintf cannot be
used without arguments any more, so use US directly.

While at it, also make newline usage consistent to not return a newline
in errptr, when it is debug-printed, a newline is added.

https://bugs.gentoo.org/720364

Signed-off-by: Fabian Groffen <grobian@gentoo.org>

# The Exim Project does not use GitHub Issues

Hey, we want your input, but we want to make sure that we actually see it and
that your help is not wasted, so please read this.

The GitHub repo exists for convenience for some folks, and to host our Wiki.
The Git repo is an automated clone of our real repo over at
<https://git.exim.org/exim.git>.

Sometimes a maintainer will take a look at GitHub pull requests, just because
we care about the software and want to know about issues, but expect long
delays.  It's not a really supported workflow.

Our bug-tracker takes code-patches and is the place to go:
<https://bugs.exim.org/>

If you've found a security bug, then please email <security@exim.org>.
All Exim Maintainers can and do use PGP.
Keyring: <https://ftp.exim.org/pub/exim/Exim-Maintainers-Keyring.asc>
We don't have a re-encrypting mailer, just encrypt to all of them please.

## If this is too much hassle ...

We do periodically get around to checking GitHub Pull Requests.
It just won't be fast.

Patches should update the documentation, `doc/doc-docbook/spec.xfpt`; if you
like, just provide the plaintext which should go in there and we can mark it
up.

If it's a whole new feature, then please guard it with a build
option `EXPERIMENTAL_FOO`; docs are in plaintext in
`doc/doc-txt/experimental-spec.txt`.

If you're feeling particularly thorough, these files get updated too:
* `doc/doc-txt/ChangeLog` : all changes; workflow pre-dates Git
* `doc/doc-txt/NewStuff` : if it's a change in intended behavior which postmasters should read
* `doc/doc-txt/OptionLists.txt` : (we usually defer this until cutting a release)
* `src/README.UPDATING` : if you're breaking backwards compatibility

Thanks!
