### PR TITLE
Don't accept overly long IPv6 numbers

### DIFF
--- a/src/src/string.c
+++ b/src/src/string.c
@@ -112,7 +112,7 @@ if (Ustrchr(s, ':') != NULL)
     component. */
 
     if (!isxdigit(*s++)) return 0;
-    if (isxdigit(*s) && isxdigit(*(++s)) && isxdigit(*(++s))) s++;
+    if (isxdigit(*s) && isxdigit(*(++s)) && isxdigit(*(++s)) && isxdigit(*(++s))) return 0;
 
     /* If the component is terminated by colon and there is more to
     follow, skip over the colon. If there is no more to follow the address is


### PR DESCRIPTION
The current code stops parsing a hex number after 4 digits and then
loops around to look for punctuation.  If none is found, it just
starts parsing more hex digits, so it will accept invalid IPv6 such
as `1::1234567890abcdef`

My simple tweak makes it return 0 if a 5th digit is found.