### PR TITLE
ALPN callback point to correct out protocol (OpenSSL)

### DIFF
--- a/src/src/tls-openssl.c
+++ b/src/src/tls-openssl.c
@@ -2182,9 +2182,9 @@ if (  inlen > 1		/* at least one name */
   for (uschar * name; name = string_nextinlist(&list, &sep, NULL, 0); )
     if (Ustrncmp(in+1, name, in[0]) == 0)
       {
-      *out = in;			/* we checked for exactly one, so can just point to it */
-      *outlen = inlen;
-      return SSL_TLSEXT_ERR_OK;		/* use ALPN */
+        *out = (unsigned char *)in + 1;
+        *outlen = in[0];
+        return SSL_TLSEXT_ERR_OK; /* use ALPN */
       }
   }
 


### PR DESCRIPTION
In the current OpenSSL implementation of ALPN the server returns the length of the alpn string inside the string.

This results in the server sending back "\004smtp" with a length of 5 when the client requests "smtp" with a length of 4 as a protocol.
 `in` is a vector in protocol-list format and `out` needs to be one of those protocols.
 
 This pull request changes the selection to be like the reference implementation of OpenSSL in the helper function `SSL_select_next_proto` (see https://github.com/openssl/openssl/blob/master/ssl/ssl_lib.c#L2933)
 
 see also https://www.openssl.org/docs/man1.1.1/man3/SSL_set_alpn_protos.html
  
 Wireshark debug output
 --------------------CLIENTHELLO
Extension: application_layer_protocol_negotiation (len=7)
    Type: application_layer_protocol_negotiation (16)
    Length: 7
    ALPN Extension Length: 5
    ALPN Protocol
        ALPN string length: 4
        ALPN Next Protocol: smtp

-----------------SERVERHELLO
Extension: application_layer_protocol_negotiation (len=8)
    Type: application_layer_protocol_negotiation (16)
    Length: 8
    ALPN Extension Length: 6
    ALPN Protocol
        ALPN string length: 5
        ALPN Next Protocol: \004smtp

(Submitting this pull request on github since bugs.exim.org gives me an error while trying to sign up
"There was an error sending mail from 'admin@bugs.exim.org' to 'REDACTED' Couldn't connect to localhost" )

EDIT: Reported the bug under Bug 2805 - 4.95 ALPN callback returns protocol prefixed with length