### PR TITLE
Add new option tls_ignore_missing_close_notify

### DIFF
--- a/doc/doc-txt/OptionLists.txt
+++ b/doc/doc-txt/OptionLists.txt
@@ -267,6 +267,7 @@ gecos_pattern                        string          unset         main
 gethostbyname                        boolean         false         smtp
 gnutls_allow_auto_pkcs11             boolean         false         main              4.82
 gnutls_compat_mode                   boolean         unset         main              4.70
+tls_ignore_missing_close_notify      boolean         true          main              (todo git master)
 gnutls_require_kx                    string*         unset         main              4.67 deprecated, warns
                                      string*         unset         smtp              4.67 deprecated, warns
 gnutls_require_mac                   string*         unset         main              4.67 deprecated, warns

--- a/src/src/globals.c
+++ b/src/src/globals.c
@@ -120,6 +120,7 @@ uschar *dsn_advertise_hosts    = NULL;
 
 #ifndef DISABLE_TLS
 BOOL    gnutls_compat_mode     = FALSE;
+BOOL    tls_ignore_missing_close_notify = TRUE;
 BOOL    gnutls_allow_auto_pkcs11 = FALSE;
 uschar *hosts_require_alpn     = NULL;
 uschar *openssl_options        = NULL;

--- a/src/src/globals.h
+++ b/src/src/globals.h
@@ -128,6 +128,7 @@ extern tls_support tls_out;
 
 #ifndef DISABLE_TLS
 extern BOOL    gnutls_compat_mode;     /* Less security, more compatibility */
+extern BOOL    tls_ignore_missing_close_notify; /* For semi-broken TLS servers like Gmail and Yandex */
 extern BOOL    gnutls_allow_auto_pkcs11; /* Let GnuTLS autoload PKCS11 modules */
 extern uschar *hosts_require_alpn;     /* Mandatory ALPN successful nogitiation */
 extern uschar *openssl_options;        /* OpenSSL compatibility options */

--- a/src/src/readconf.c
+++ b/src/src/readconf.c
@@ -168,6 +168,7 @@ static optionlist optionlist_config[] = {
 #ifndef DISABLE_TLS
   { "gnutls_allow_auto_pkcs11", opt_bool,        {&gnutls_allow_auto_pkcs11} },
   { "gnutls_compat_mode",       opt_bool,        {&gnutls_compat_mode} },
+  { "tls_ignore_missing_close_notify", opt_bool, {&tls_ignore_missing_close_notify} },
 #endif
   { "header_line_maxsize",      opt_int,         {&header_line_maxsize} },
   { "header_maxsize",           opt_int,         {&header_maxsize} },

--- a/src/src/tls-gnu.c
+++ b/src/src/tls-gnu.c
@@ -4034,14 +4034,20 @@ do
 while (inbytes == GNUTLS_E_AGAIN);
 
 if (inbytes > 0) return inbytes;
-if (inbytes == 0)
+if (inbytes == 0
+    // there is a "bug" in Gmail and Yandex servers where they do not send the tls-protocol-mandated `close_notify` on connection close.
+    // They do it intentionally to save time (skip a roundtrip), but it is against tls-protocol and does spam the exim4 errorlogs like
+    // 2024-10-12 09:22:27 1szVWE-0071qn-2C H=gmail-smtp-in.l.google.com [142.250.102.27] TLS error on connection (recv_tls_read): The TLS connection was non-properly terminated.
+    // optionally treat this as a normal EOF.
+    // This is equivalent to OpenSSL's SSL_OP_IGNORE_UNEXPECTED_EOF flag.
+    || (tls_ignore_missing_close_notify && inbytes == GNUTLS_E_PREMATURE_TERMINATION))
   {
-  DEBUG(D_tls) debug_printf("Got TLS_EOF\n");
+    DEBUG(D_tls) debug_printf("Got TLS_EOF\n");
   }
 else
   {
-  DEBUG(D_tls) debug_printf("%s: err from gnutls_record_recv\n", __FUNCTION__);
-  record_io_error(state, (int)inbytes, US"recv", NULL);
+    DEBUG(D_tls) debug_printf("%s: err from gnutls_record_recv\n", __FUNCTION__);
+    record_io_error(state, (int)inbytes, US"recv", NULL);
   }
 
 return -1;

--- a/src/src/tls-openssl.c
+++ b/src/src/tls-openssl.c
@@ -2954,6 +2954,12 @@ if (init_options)
 #ifdef OPENSSL_MIN_PROTO_VERSION
   SSL_CTX_set_min_proto_version(ctx, SSL3_VERSION);
 #endif
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+  if(tls_ignore_missing_close_notify) {
+    init_options |= SSL_OP_IGNORE_UNEXPECTED_EOF;
+  }
+#endif
+
   DEBUG(D_tls) debug_printf("setting  SSL CTX options: %016lx\n", init_options);
   SSL_CTX_set_options(ctx, init_options);
    {


### PR DESCRIPTION
- Introduced tls_ignore_missing_close_notify to handle servers that do not send the TLS close_notify alert on shutdown.
- This addresses a common issue with both Gmail and Yandex servers, which intentionally omit close_notify to save a roundtrip, despite it being against the TLS protocol.
- Without this option, the omission generates spurious errors in logs, such as: "2024-10-12 09:22:27 1szVWE-0071qn-2C H=gmail-smtp-in.l.google.com [142.250.102.27] TLS error on connection (recv_tls_read): The TLS connection was non-properly terminated."
- The new option allows treating this as a normal EOF, equivalent to OpenSSL's SSL_OP_IGNORE_UNEXPECTED_EOF.

# The Exim Project does not use GitHub Issues

Hey, we want your input, but we want to make sure that we actually see it and
that your help is not wasted, so please read this.

The GitHub repo exists for convenience for some folks, and to host our Wiki.
The Git repo is an automated clone of our real repo over at
<https://git.exim.org/exim.git>.

Sometimes a maintainer will take a look at GitHub pull requests, just because
we care about the software and want to know about issues, but expect long
delays.  It's not a really supported workflow.

Our bug-tracker takes code-patches and is the place to go:
<https://bugs.exim.org/>

If you've found a security bug, then please email <security@exim.org>.
All Exim Maintainers can and do use PGP.
Keyring: <https://ftp.exim.org/pub/exim/Exim-Maintainers-Keyring.asc>
We don't have a re-encrypting mailer, just encrypt to all of them please.

## If this is too much hassle ...

We do periodically get around to checking GitHub Pull Requests.
It just won't be fast.

Patches should update the documentation, `doc/doc-docbook/spec.xfpt`; if you
like, just provide the plaintext which should go in there and we can mark it
up.

If it's a whole new feature, then please guard it with a build
option `EXPERIMENTAL_FOO`; docs are in plaintext in
`doc/doc-txt/experimental-spec.txt`.

If you're feeling particularly thorough, these files get updated too:
* `doc/doc-txt/ChangeLog` : all changes; workflow pre-dates Git
* `doc/doc-txt/NewStuff` : if it's a change in intended behavior which postmasters should read
* `doc/doc-txt/OptionLists.txt` : (we usually defer this until cutting a release)
* `src/README.UPDATING` : if you're breaking backwards compatibility

Thanks!
